### PR TITLE
Fixes in FDU network status information structure, and custom node id assignment on Linux

### DIFF
--- a/fos-plugins/KVM/KVM_plugin
+++ b/fos-plugins/KVM/KVM_plugin
@@ -834,13 +834,24 @@ class KVM(RuntimePluginFDU):
                     # >>> dom.interfaceStats(iface)
                     # (40751, 700, 0, 0, 9976, 119, 0, 0) -> bytes read, packets read, read errors, read drops, bytes written, packets written, write error, write drops
 
-                    c_net = []
+                    c_net = {}
                     for i in record.get('interfaces'):
                         ip = self.call_nw_plugin_function('get_address', {'mac_address':i.get('mac_address','')})
-                        c_net.append(
-                            {'name': i['vintf_name'],
-                            'mac_address': i.get('mac_address',''),
-                            'address': ip}
+                        # c_net.append(
+                        #     {'name': i['vintf_name'],
+                        #     'mac_address': i.get('mac_address',''),
+                        #     'address': ip}
+                        # )
+                        c_net.update(
+                            {
+                                i['vintf_name']:
+                                {
+                                'hwaddr': i.get('mac_address',''),
+                                'addresses': [
+                                    {'address': ip}
+                                    ]
+                                }
+                            }
                         )
 
                     vm_mem_info = dom.memoryStats()

--- a/fos-plugins/LXD/LXD_plugin
+++ b/fos-plugins/LXD/LXD_plugin
@@ -842,13 +842,24 @@ class LXD(RuntimePluginFDU):
                     #
                     #if c_net is None:
                     #    c_net = []
-                    c_net = []
+                    c_net = {}
                     for i in record.get('interfaces'):
                         ip = self.call_nw_plugin_function('get_address', {'mac_address':i.get('mac_address','')})
-                        c_net.append(
-                            {'name': i['vintf_name'],
-                            'mac_address': i.get('mac_address',''),
-                            'address': ip}
+                        # c_net.append(
+                        #     {'name': i['vintf_name'],
+                        #     'mac_address': i.get('mac_address',''),
+                        #     'address': ip}
+                        # )
+                        c_net.update(
+                            {
+                                i['vintf_name']:
+                                {
+                                'hwaddr': i.get('mac_address',''),
+                                'addresses': [
+                                    {'address': ip}
+                                    ]
+                                }
+                            }
                         )
 
 

--- a/fos-plugins/linux/linux_plugin
+++ b/fos-plugins/linux/linux_plugin
@@ -665,23 +665,8 @@ class Linux(OSPlugin):
         return {'result':self.nw_devices}
 
     def get_uuid(self):
-        # $ blkid / dev / sda1
-        # /dev/sda1: LABEL = '/'  UUID = 'ee7cf0a0-1922-401b-a1ae-6ec9261484c0' SEC_TYPE = 'ext2' TYPE = 'ext3'
-        # generate uuid from this or from cpuid or mb uuid from /sys/class/dmi/id/product_uuid
-        '''
-
-        uuid_regex = r"PARTUUID=\"(.{0,37})\""
-        p = psutil.Popen('sudo blkid /dev/sda1'.split(), stdout=PIPE)
-        res = ""
-        for line in p.stdout:
-            res = str(res+"%s" % line)
-        m = re.search(uuid_regex, res)
-        if m:
-            found = m.group(1)
-        return found
-        :return:
-        '''
-
+        if os.path.isfile('/etc/fos/nodeid'):
+            return read_file('/etc/fos/nodeid')
         # p = psutil.Popen('sudo cat /sys/class/dmi/id/product_uuid'.split(), stdout=PIPE)
         p = psutil.Popen('sudo cat /etc/machine-id'.split(), stdout=PIPE)
         # p = psutil.Popen('sudo cat '.split(), stdout=PIPE)

--- a/src/core/ocaml/fos-core/fos_core.ml
+++ b/src/core/ocaml/fos-core/fos_core.ml
@@ -74,10 +74,17 @@ let get_unix_syslog_reporter () =
 let getuuid () =
   match String.uppercase_ascii @@ get_platform () with
   | "LINUX" ->
-    let ic = Pervasives.open_in "/etc/machine-id" in
+    let fname =
+      match Sys.file_exists "/etc/fos/nodeid" with
+      | false -> "/etc/machine-id"
+      | true -> "/etc/fos/nodeid"
+    in
+    let ic = Pervasives.open_in fname in
     let uuid = input_line ic in
     let _ = close_in ic in
-    String.sub uuid 0 8 ^ "-" ^ String.sub uuid 8 4 ^ "-" ^ String.sub uuid 12 4 ^ "-" ^ String.sub uuid 16 4 ^ "-" ^ String.sub uuid 20 12
+    (match String.index_opt uuid '-' with
+     | Some _ ->  uuid
+     | None ->  String.sub uuid 0 8 ^ "-" ^ String.sub uuid 8 4 ^ "-" ^ String.sub uuid 12 4 ^ "-" ^ String.sub uuid 16 4 ^ "-" ^ String.sub uuid 20 12)
   | "DARWIN" ->
     let ic = Unix.open_process_in "ioreg -rd1 -c IOPlatformExpertDevice |  awk '/IOPlatformUUID/ { print $3; }'" in
     let uuid = input_line ic in

--- a/src/im/python/examples/example.json
+++ b/src/im/python/examples/example.json
@@ -1,13 +1,23 @@
 {
-    "appd-descriptor": {
-        "id": "example-meapp1",
-        "name": "example_mec_application",
-        "vendor": "ADLINK",
-        "version": "1.0",
-        "soft-version": "",
-        "mec-version": [
-            "1"
-        ],
-        "description": "Simple MEC Application"
+    "appDId": "example-meapp1",
+    "appName": "example_mec_application",
+    "appProvider": "ADLINK",
+    "appDVersion": "1.0",
+    "appSoftVersion": "",
+    "mecVersion": [
+        "1"
+    ],
+    "appDescription": "Simple MEC Application",
+    "appServiceRequired": [],
+    "appServiceOptional": [],
+    "appServiceProduced": [],
+    "appFeatureRequired": [],
+    "appFeatureOptional": [],
+    "transportDependencies": [],
+    "appTrafficRule": [],
+    "appDNSRule": [],
+    "appLatency": {
+        "timeUnit": 10,
+        "latency": "ms"
     }
 }


### PR DESCRIPTION
FIxes:
- FDU status information structure, to mantain the same strucutre used by LXD FDUs for KVM FDUs, and mantain compatibility with ETSI OSM r6
- Linux node can now use a custom UUID, they just need to create th file `/etc/fos/nodeid` with a proper UUID4 (this format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) and that UUID will be used instead of the machine-id 