### PR TITLE
Updated custom nodeid configuration

### DIFF
--- a/fos-plugins/LXD/LXD_plugin
+++ b/fos-plugins/LXD/LXD_plugin
@@ -146,7 +146,10 @@ class LXD(RuntimePluginFDU):
             try:
                 img = self.conn.images.get_by_alias(k)
                 imgd = self.images[k]
-                self.call_os_plugin_function('remove_file',{'file_path':os.path.join(self.BASE_DIR, self.IMAGE_DIR, imgd['base_image'])})
+                try:
+                    self.call_os_plugin_function('remove_file',{'file_path':os.path.join(self.BASE_DIR, self.IMAGE_DIR, imgd['base_image'])})
+                except ValueError:
+                     self.logger.info('stop_runtime()', 'Removing Image file {} not exist'.format(os.path.join(self.BASE_DIR, self.IMAGE_DIR, imgd['base_image'])))
                 img.delete()
             except LXDAPIException as e:
                 self.logger.error('stop_runtime()', 'Error {}'.format(e))


### PR DESCRIPTION
Updated the custom nodeid configuration, by adding a parameter to the agent.
So in ordert to use the custom id you need to start the agent passing the -i parameter

```
sudo -u fos fagent -c /etc/fos/agent.json -v -i 00000000-0000-0000-0000-000000000001
```

In this case also all the configuartion files used for the plugins have to be updated with this UUID, it is possible to have multiple configuration file for each plugin and start the plugin with the correct configuration file.

eg.

```
sudo -u fos fos_linux /etc/fos/plugins/linux/nodecustom.json
sudo -u fos /etc/fos/plugins/linuxbridge/linuxbridge_plugin /etc/fos/pgins/linuxbridge/nodecustom.json
sudo -u fos /etc/fos/plugins/LXD/LXD_plugin /etc/fos/plugins/LXD/nodecustom.json
```

This can allow to run multiple agents in the same physical machine, but in that case it will not be possible to use the LinuxBridge plugin as the name of the virtual interface will collide causing unpredicted behaviour.
