### PR TITLE
Runtime connection of connection point to vNetworks

### DIFF
--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -519,6 +519,7 @@ class LinuxBridge(NetworkPlugin):
         self.logger.info('disconnect_cp()','CP info {}'.format(cp_info))
         ext_cp = cp_info.get('ext_name')
         cmd = 'sudo ip link set dev {} nomaster'.format(ext_cp)
+        self.call_os_plugin_function('execute_command',{'command':cmd,'blocking':True, 'external':False})
         self.logger.info('disconnect_cp()','Disconnected CP {}'.format(cp_id))
         return {'result':{'int':cp_id, 'ext':None}}
 

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -510,13 +510,16 @@ class LinuxBridge(NetworkPlugin):
 
     # eval
     def disconnect_cp(self, cp_id):
+        self.logger.info('disconnect_cp()','Disconnecting CP {}'.format(cp_id))
         cp_info = self.ports.get(cp_id)
         if cp_info is None:
             self.logger.error('disconnect_interface',
             'Connection point does not exist')
             return {'error':-2}
+        self.logger.info('disconnect_cp()','CP info {}'.format(cp_info))
         ext_cp = cp_info.get('ext_name')
         cmd = 'sudo ip link set dev {} nomaster'.format(ext_cp)
+        self.logger.info('disconnect_cp()','Disconnected CP {}'.format(cp_id))
         return {'result':{'int':cp_id, 'ext':None}}
 
 

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -279,10 +279,13 @@ let agent verbose_flag debug_flag configuration custom_uuid =
   in
   (* NM Evals *)
   let eval_connect_cp_to_network self (props:Apero.properties) =
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP - ##############") in
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let%lwt net_p = get_network_plugin self in
     let cp_id = Apero.Option.get @@ Apero.Properties.get "cp_uuid" props in
     let net_id = Apero.Option.get @@ Apero.Properties.get "network_uuid" props in
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP - # NetManager: %s" net_p) in
     try%lwt
       let parameters = [("cp_id",cp_id);("vnet_id", net_id)] in
       let fname = "connect_cp_to_vnetwork" in
@@ -297,9 +300,12 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   let eval_remove_cp_from_network self (props:Apero.properties) =
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP - ##############") in
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let%lwt net_p = get_network_plugin self in
     let cp_id = Apero.Option.get @@ Apero.Properties.get "cp_uuid" props in
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP - # NetManager: %s" net_p) in
     try%lwt
       let parameters = [("cp_id",cp_id)] in
       let fname = "disconnect_cp" in

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -854,12 +854,12 @@ let agent verbose_flag debug_flag configuration custom_uuid =
   let%lwt _ = Yaks_connector.Local.Actual.add_agent_eval uuid "get_port_info" (eval_get_port_info state) yaks in
   let%lwt _ = Yaks_connector.Local.Actual.add_agent_eval uuid "get_image_info" (eval_get_image_info state) yaks in
   (* Network Mgmt Evals *)
-  let%lwt _ = Yaks_connector.Local.Actual.add_agent_eval uuid "add_port_to_network" (eval_connect_cp_to_network state) yaks in
-  let%lwt _ = Yaks_connector.Local.Actual.add_agent_eval uuid "remove_port_from_network" (eval_remove_cp_from_network state) yaks in
-  let%lwt _ = Yaks_connector.Local.Actual.add_agent_eval uuid "create_floating_ip" (eval_create_floating_ip state) yaks in
-  let%lwt _ = Yaks_connector.Local.Actual.add_agent_eval uuid "delete_floating_ip" (eval_delete_floating_ip state) yaks in
-  let%lwt _ = Yaks_connector.Local.Actual.add_agent_eval uuid "assign_floating_ip" (eval_assign_floating_ip state) yaks in
-  let%lwt _ = Yaks_connector.Local.Actual.add_agent_eval uuid "remove_floating_ip" (eval_remove_floating_ip state) yaks in
+  let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "add_port_to_network" (eval_connect_cp_to_network state) yaks in
+  let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "remove_port_from_network" (eval_remove_cp_from_network state) yaks in
+  let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "create_floating_ip" (eval_create_floating_ip state) yaks in
+  let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "delete_floating_ip" (eval_delete_floating_ip state) yaks in
+  let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "assign_floating_ip" (eval_assign_floating_ip state) yaks in
+  let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "remove_floating_ip" (eval_remove_floating_ip state) yaks in
   (* Constraint Eval  *)
   let%lwt _ = Yaks_connector.LocalConstraint.Actual.add_agent_eval uuid "get_fdu_info" (eval_get_fdu_info state) yaks in
   (* Registering listeners *)

--- a/src/api/python/api/fog05/fimapi.py
+++ b/src/api/python/api/fog05/fimapi.py
@@ -365,7 +365,7 @@ class FIMAPI(object):
                 n, pid = p
                 if pid == cp_uuid:
                     port_info = self.connector.glob.actual.get_node_network_port(self. sysid, self.tenantid, n, pid)
-            if node is None and port_info is None:
+            if node is None or port_info is None:
                 raise ValueError('Connection point {} not found'.format(cp_uuid))
             res = self.connector.glob.actual.remove_node_port_from_network(self.sysid, self.tenantid, node, port_info['uuid'])
             if res.get('result') is not None:

--- a/src/api/python/api/fog05/fimapi.py
+++ b/src/api/python/api/fog05/fimapi.py
@@ -349,7 +349,8 @@ class FIMAPI(object):
                 n, pid = p
                 if pid == cp_uuid:
                     port_info = self.connector.glob.actual.get_node_network_port(self. sysid, self.tenantid, n, pid)
-            if node is None and port_info is None:
+                    node = n
+            if node is None or port_info is None:
                 raise ValueError('Connection point {} not found'.format(cp_uuid))
             res = self.connector.glob.actual.add_node_port_to_network(self.sysid, self.tenantid, node, port_info['uuid'], net_uuid)
             if res.get('result') is not None:

--- a/src/api/python/api/fog05/fimapi.py
+++ b/src/api/python/api/fog05/fimapi.py
@@ -342,10 +342,34 @@ class FIMAPI(object):
                 self.sysid, self.tenantid, cp_uuid, manifest)
 
         def connect_cp_to_network(self, cp_uuid, net_uuid):
-            pass
+            ports = self.connector.glob.actual.get_all_nodes_network_ports(self.sysid, self.tenantid)
+            node = None
+            port_info = None
+            for p in ports:
+                n, pid = p
+                if pid == cp_uuid:
+                    port_info = self.connector.glob.actual.get_node_network_port(self. sysid, self.tenantid, n, pid)
+            if node is None and port_info is None:
+                raise ValueError('Connection point {} not found'.format(cp_uuid))
+            res = self.connector.glob.actual.add_node_port_to_network(self.sysid, self.tenantid, node, port_info['uuid'], net_uuid)
+            if res.get('result') is not None:
+                return cp_uuid
+            raise ValueError('Error connecting: {}'.format(res['error']))
 
         def disconnect_cp(self, cp_uuid):
-            pass
+            ports = self.connector.glob.actual.get_all_nodes_network_ports(self.sysid, self.tenantid)
+            node = None
+            port_info = None
+            for p in ports:
+                n, pid = p
+                if pid == cp_uuid:
+                    port_info = self.connector.glob.actual.get_node_network_port(self. sysid, self.tenantid, n, pid)
+            if node is None and port_info is None:
+                raise ValueError('Connection point {} not found'.format(cp_uuid))
+            res = self.connector.glob.actual.remove_node_port_from_network(self.sysid, self.tenantid, node, port_info['uuid'])
+            if res.get('result') is not None:
+                return cp_uuid
+            raise ValueError('Error connecting: {}'.format(res['error']))
 
         def list(self):
             '''

--- a/src/api/python/api/fog05/fimapi.py
+++ b/src/api/python/api/fog05/fimapi.py
@@ -365,6 +365,7 @@ class FIMAPI(object):
                 n, pid = p
                 if pid == cp_uuid:
                     port_info = self.connector.glob.actual.get_node_network_port(self. sysid, self.tenantid, n, pid)
+                    node = n
             if node is None or port_info is None:
                 raise ValueError('Connection point {} not found'.format(cp_uuid))
             res = self.connector.glob.actual.remove_node_port_from_network(self.sysid, self.tenantid, node, port_info['uuid'])

--- a/src/api/python/api/fog05/yaks_connector.py
+++ b/src/api/python/api/fog05/yaks_connector.py
@@ -745,7 +745,7 @@ class GAD(object):
 
     def add_node_port_to_network(self, sysid, tenantid,  nodeid, portid, network_id):
         fname = "add_port_to_network"
-        params = {'cp_uuid': portid, 'vnet_id':network_id}
+        params = {'cp_uuid': portid, 'network_uuid':network_id}
         s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
         res = self.ws.eval(s)
         if len(res) == 0:

--- a/src/api/python/api/fog05/yaks_connector.py
+++ b/src/api/python/api/fog05/yaks_connector.py
@@ -204,12 +204,12 @@ class GAD(object):
             self.prefix, sysid, 'tenants', tenantid, 'nodes', nodeid,
             'networks', 'floating-ips', '*', 'info'])
 
-    def get_network_ports_selector(self, sysid, tenantid):
+    def get_node_network_ports_selector(self, sysid, tenantid):
         return Constants.create_path(
             [self.prefix, sysid, 'tenants', tenantid,
             'nodes', '*', 'networks', 'ports', '*', 'info'])
 
-    def get_network_port_info_path(self, sysid, tenantid, nodeid, portid):
+    def get_node_network_port_info_path(self, sysid, tenantid, nodeid, portid):
         return Constants.create_path(
             [self.prefix, sysid, 'tenants', tenantid,
             'nodes', nodeid, 'networks', 'ports', portid, 'info'])
@@ -720,7 +720,7 @@ class GAD(object):
         return d
 
     def get_all_nodes_network_ports(self, sysid, tenantid):
-        s = self.get_network_ports_selector(sysid, tenantid)
+        s = self.get_node_network_ports_selector(sysid, tenantid)
         res = self.ws.get(s)
         if len(res) == 0:
             return []
@@ -731,7 +731,7 @@ class GAD(object):
         return list(xs)
 
     def get_node_network_port(self, sysid, tenantid, nodeid,  portid):
-        p = self.get_network_port_info_path(sysid, tenantid, nodeid, portid)
+        p = self.get_node_network_port_info_path(sysid, tenantid, nodeid, portid)
         res = self.ws.get(p)
         if len(res) == 0:
             return None

--- a/src/api/python/api/fog05/yaks_connector.py
+++ b/src/api/python/api/fog05/yaks_connector.py
@@ -100,7 +100,7 @@ class GAD(object):
         return Constants.create_path([self.prefix, sysid, 'tenants', tenantid,
                                       'nodes', nodeid, 'plugins',
                                       pluginid, 'exec', func_name])
-    # Updated paths with instances
+
     def get_node_fdu_info_path(self, sysid, tenantid, nodeid, fduid, instanceid):
         return Constants.create_path([self.prefix, sysid, 'tenants', tenantid,
                                       'nodes', nodeid, 'fdu',fduid ,
@@ -204,6 +204,45 @@ class GAD(object):
             self.prefix, sysid, 'tenants', tenantid, 'nodes', nodeid,
             'networks', 'floating-ips', '*', 'info'])
 
+    def get_network_ports_selector(self, sysid, tenantid):
+        return Constants.create_path(
+            [self.prefix, sysid, 'tenants', tenantid,
+            'nodes', '*', 'networks', 'ports', '*', 'info'])
+
+    def get_network_port_info_path(self, sysid, tenantid, nodeid, portid):
+        return Constants.create_path(
+            [self.prefix, sysid, 'tenants', tenantid,
+            'nodes', nodeid, 'networks', 'ports', portid, 'info'])
+
+
+        # TODO: this should be in the YAKS api in the creation of a selector
+    def dict2args(self, d):
+        i = 0
+        b = ''
+        for k in d:
+            v = d.get(k)
+            if isinstance(v,(dict, list)):
+                v = json.dumps(v)
+            if i == 0:
+                b = b + '{}={}'.format(k, v)
+            else:
+                b = b + ';{}={}'.format(k, v)
+            i = i + 1
+        return '('+b+')'
+
+    def get_agent_exec_path(self, sysid, tenantid, nodeid, func_name):
+        return Constants.create_path([self.prefix, sysid, "tenants",
+        tenantid, "nodes", nodeid, 'agent', 'exec', func_name])
+
+    def get_agent_exec_path_with_params(self, sysid, tenantid, nodeid, func_name, params):
+        if len(params) > 0:
+            p = self.dict2args(params)
+            f = func_name + '?' + p
+        else:
+            f = func_name
+        return Constants.create_path([self.prefix, sysid, "tenants",
+        tenantid, "nodes", nodeid, 'agent', 'exec',f])
+
 
     def extract_userid_from_path(self, path):
         return path.split('/')[4]
@@ -228,6 +267,9 @@ class GAD(object):
 
     def extract_node_instanceid_from_path(self, path):
         return path.split('/')[10]
+
+    def extract_node_port_id_from_path(self, path):
+        return path.split('/')[9]
 
     def extract_node_floatingid_from_path(self, path):
         return path.split('/')[9]
@@ -676,6 +718,50 @@ class GAD(object):
         for n in kvs:
             d.append(json.loads(kvs[0][1].get_value()))
         return d
+
+    def get_all_nodes_network_ports(self, sysid, tenantid):
+        s = self.get_network_ports_selector(sysid, tenantid)
+        res = self.ws.get(s)
+        if len(res) == 0:
+            return []
+        xs = map(lambda x:
+         (self.extract_nodeid_from_path(x[0]),
+         self.extract_node_port_id_from_path(x[0]))
+         ,res)
+        return list(xs)
+
+    def get_node_network_port(self, sysid, tenantid, nodeid,  portid):
+        p = self.get_network_port_info_path(sysid, tenantid, nodeid, portid)
+        res = self.ws.get(p)
+        if len(res) == 0:
+            return None
+        else:
+            v = res[0][1]
+            return json.loads(v.get_value())
+
+
+
+    # Agent Evals
+
+    def add_node_port_to_network(self, sysid, tenantid,  nodeid, portid, network_id):
+        fname = "add_port_to_network"
+        params = {'cp_uuid': portid, 'vnet_id':network_id}
+        s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
+        res = self.ws.eval(s)
+        if len(res) == 0:
+            raise ValueError('Empty data on exec_os_eval')
+        else:
+            return json.loads(res[0][1].get_value())
+
+    def remove_node_port_from_network(self, sysid, tenantid, nodeid, portid):
+        fname = "remove_port_from_network"
+        params = {'cp_uuid': portid}
+        s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
+        res = self.ws.eval(s)
+        if len(res) == 0:
+            raise ValueError('Empty data on exec_os_eval')
+        else:
+            return json.loads(res[0][1].get_value())
 
 
 


### PR DESCRIPTION
Added the feature of connecting a CP to a vNetwork while the FDU is running, so also at runtime.
Two new APIs added to allow this:

```
>>> a.network.connect_cp_to_network(<cp_id>, <vnet_id>)
<cp_id>
>>> a.network.disconnect_cp(<cp_id>)
<cp_id>
```

Next step is to make CP to interconnect each other, in order to have SFC.

