### PR TITLE
Makefiles and installers corrected to conform to UUID4 standard

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -9,6 +9,6 @@ These are the contributors to fog05 according to the Github repository.
  ===============  ==================================
  gabrik           Gabriele Baldoni (ADLINK)
  josrolgil        José María Roldán Gil
-
+ Davide-DD        Davide Di Donato
  ===============  ==================================
 

--- a/fos-plugins/LXD/Makefile
+++ b/fos-plugins/LXD/Makefile
@@ -1,6 +1,7 @@
 # -*-Makefile-*-
 
 WD := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))));
+UUID = $(shell ./to_uuid.sh)
 
 ETC_FOS_DIR = /etc/fos/
 VAR_FOS_DIR = /var/fos/
@@ -25,6 +26,7 @@ else
 	sudo ln -sf /etc/fos/plugins/LXD/LXD_plugin /usr/bin/fos_lxd
 endif
 	sudo cp /etc/fos/plugins/LXD/fos_lxd.service /lib/systemd/system/
+	sudo sh -c "echo $(UUID) | xargs -i  jq  '.configuration.nodeid = \"{}\"' /etc/fos/plugins/LXD/LXD_plugin.json > /tmp/LXD_plugin.tmp && mv /tmp/LXD_plugin.tmp /etc/fos/plugins/LXD/LXD_plugin.json"
 
 
 uninstall:

--- a/fos-plugins/LXD/to_uuid.sh
+++ b/fos-plugins/LXD/to_uuid.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+id=$(cat /etc/machine-id)
+first=$(echo $id | cut -c -8)
+second=$(echo $id | cut -c 9-12)
+third=$(echo $id | cut -c 13-16)
+fourth=$(echo $id | cut -c 17-20)
+fifth=$(echo $id | cut -c 21-)
+echo $first-$second-$third-$fourth-$fifth

--- a/fos-plugins/linuxbridge/Makefile
+++ b/fos-plugins/linuxbridge/Makefile
@@ -1,6 +1,7 @@
 # -*-Makefile-*-
 
 WD := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))));
+UUID = $(shell ./to_uuid.sh)
 
 LB_PLUGIN_DIR = /etc/fos/plugins/linuxbridge
 LB_PLUGIN_CONFFILE = /etc/fos/plugins/linuxbridge/linuxbridge_plugin.json
@@ -19,6 +20,7 @@ else
 	sudo ln -sf /etc/fos/plugins/linuxbridge/linuxbridge_plugin /usr/bin/fos_linuxbridge
 endif
 	sudo cp /etc/fos/plugins/linuxbridge/fos_linuxbridge.service /lib/systemd/system/
+	sudo sh -c "echo $(UUID) | xargs -i  jq  '.configuration.nodeid = \"{}\"' /etc/fos/plugins/linuxbridge/linuxbridge_plugin.json > /tmp/linuxbridge_plugin.tmp && mv /tmp/linuxbridge_plugin.tmp /etc/fos/plugins/linuxbridge/linuxbridge_plugin.json"
 
 
 uninstall:

--- a/fos-plugins/linuxbridge/to_uuid.sh
+++ b/fos-plugins/linuxbridge/to_uuid.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+id=$(cat /etc/machine-id)
+first=$(echo $id | cut -c -8)
+second=$(echo $id | cut -c 9-12)
+third=$(echo $id | cut -c 13-16)
+fourth=$(echo $id | cut -c 17-20)
+fifth=$(echo $id | cut -c 21-)
+echo $first-$second-$third-$fourth-$fifth

--- a/fos_install.sh
+++ b/fos_install.sh
@@ -5,6 +5,15 @@
 # git checkout 0.2-devel
 
 
+function to_uuid() {
+	first=$(echo $1 | cut -c -8)
+	second=$(echo $1 | cut -c 9-12)
+	third=$(echo $1 | cut -c 13-16)
+	fourth=$(echo $1 | cut -c 17-20)
+	fifth=$(echo $1 | cut -c 21-)
+	echo $first-$second-$third-$fourth-$fifth
+}
+
 
 
 MACHINE_TYPE=`uname -m`
@@ -33,7 +42,9 @@ rm -rf /tmp/fos.tar.gz
 
 sudo make install
 
-sudo sh -c "cat /etc/machine-id | xargs -i  jq  '.configuration.nodeid = \"{}\"' /etc/fos/plugins/linux/linux_plugin.json > /tmp/linux_plugin.tmp && mv /tmp/linux_plugin.tmp /etc/fos/plugins/linux/linux_plugin.json"
+uuid=$(to_uuid $(cat '/etc/machine-id'))
+
+sudo sh -c "echo $uuid | xargs -i  jq  '.configuration.nodeid = \"{}\"' /etc/fos/plugins/linux/linux_plugin.json > /tmp/linux_plugin.tmp && mv /tmp/linux_plugin.tmp /etc/fos/plugins/linux/linux_plugin.json"
 
 echo 'You may want to install the other plugins, look at the fos-plugins directory!'
 

--- a/install_fos_lxd.sh
+++ b/install_fos_lxd.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+function to_uuid() {
+	first=$(echo $1 | cut -c -8)
+	second=$(echo $1 | cut -c 9-12)
+	third=$(echo $1 | cut -c 13-16)
+	fourth=$(echo $1 | cut -c 17-20)
+	fifth=$(echo $1 | cut -c 21-)
+	echo $first-$second-$third-$fourth-$fifth
+}
+
 git clone https://github.com/eclipse/fog05
 cd fog05
 
@@ -41,11 +50,13 @@ rm -rf /tmp/fos.tar.gz
 
 sudo make install
 
-sudo sh -c "cat /etc/machine-id | xargs -i  jq  '.configuration.nodeid = \"{}\"' /etc/fos/plugins/linux/linux_plugin.json > /tmp/linux_plugin.tmp && mv /tmp/linux_plugin.tmp /etc/fos/plugins/linux/linux_plugin.json"
+uuid=$(to_uuid $(cat '/etc/machine-id'))
+
+sudo sh -c "echo $uuid | xargs -i  jq  '.configuration.nodeid = \"{}\"' /etc/fos/plugins/linux/linux_plugin.json > /tmp/linux_plugin.tmp && mv /tmp/linux_plugin.tmp /etc/fos/plugins/linux/linux_plugin.json"
 
 sudo make -C fos-plugins/linuxbridge install
 
-sudo sh -c "cat /etc/machine-id | xargs -i  jq  '.configuration.nodeid = \"{}\"' /etc/fos/plugins/linuxbridge/linuxbridge_plugin.json > /tmp/linuxbridge.tmp && mv /tmp/linuxbridge.tmp /etc/fos/plugins/linuxbridge/linuxbridge_plugin.json"
+sudo sh -c "echo $uuid | xargs -i  jq  '.configuration.nodeid = \"{}\"' /etc/fos/plugins/linuxbridge/linuxbridge_plugin.json > /tmp/linuxbridge.tmp && mv /tmp/linuxbridge.tmp /etc/fos/plugins/linuxbridge/linuxbridge_plugin.json"
 
 DP_FACE=$(awk '$2 == 00000000 { print $1 }' /proc/net/route | head -n 1)
 
@@ -53,7 +64,7 @@ sudo sh -c "jq '.configuration.dataplane_interface = \"$DP_FACE\"' /etc/fos/plug
 
 sudo make -C fos-plugins/LXD install
 
-sudo sh -c "cat /etc/machine-id | xargs -i  jq  '.configuration.nodeid = \"{}\"' /etc/fos/plugins/LXD/LXD_plugin.json > /tmp/lxd.tmp && mv /tmp/lxd.tmp /etc/fos/plugins/LXD/LXD_plugin.json"
+sudo sh -c "echo $uuid | xargs -i  jq  '.configuration.nodeid = \"{}\"' /etc/fos/plugins/LXD/LXD_plugin.json > /tmp/lxd.tmp && mv /tmp/lxd.tmp /etc/fos/plugins/LXD/LXD_plugin.json"
 
 sudo make -C src/utils/python/rest_proxy install
 


### PR DESCRIPTION
As discussed in [this issue](https://github.com/eclipse/fog05/issues/122#issue-465426283), I'm uploading some corrections to various makefiles and installers in order to **transform the machine-id to a valid UUID string** prior to store it in plugins' configuration files. This **aligns the node ID stored in YAKS and the node ID saved in the configuration files**, thus leading to have fog05 working right after the end of the installation without having to modify the node ID for each plugin configuration file.