### PR TITLE
Fixing monitoring for FDUs

### DIFF
--- a/fos-plugins/LXD/LXD_plugin
+++ b/fos-plugins/LXD/LXD_plugin
@@ -831,13 +831,13 @@ class LXD(RuntimePluginFDU):
         pass
 
     def __monitor_instance(self, fdu_uuid, instance_id, instance_name):
-        self.logger.info('__monitor_fdu()','[ INFO ] LXD Plugin - Staring monitoring of Container uuid {}'.format(instance_id))
+        self.logger.info('__monitor_instance()','[ INFO ] LXD Plugin - Staring monitoring of Container uuid {}'.format(instance_id))
         while True:
             time.sleep(self.update_interval)
             try:
                 record = self.connector.loc.actual.get_node_fdu(self.node, self.uuid, fdu_uuid, instance_id)
                 if record.get('status') not in ['LAND', 'TAKE_OFF','MIGRATE']:
-                    self.logger.info('__monitor_fdu()','[ INFO ] LXD Plugin - Updating status of {}'.format(fdu_uuid))
+                    self.logger.info('__monitor_instance()','[ INFO ] LXD Plugin - Updating status of {}'.format(fdu_uuid))
                     c = self.conn.containers.get(instance_name)
                     cs = c.state()
                     detailed_state = {}
@@ -858,7 +858,10 @@ class LXD(RuntimePluginFDU):
                     #    c_net = []
                     c_net = {}
                     for i in record.get('interfaces'):
-                        ip = self.call_nw_plugin_function('get_address', {'mac_address':i.get('mac_address','')})
+                        try:
+                            ip = self.call_nw_plugin_function('get_address', {'mac_address':i.get('mac_address','')})
+                        except ValueError:
+                            ip = ''
                         # Getting address from LXD if unable from network manager, eg. if connected to physical device/lxd bridge
                         if ip == '':
                             lxd_net_info_addrs = cs.network[i['vintf_name']]['addresses']

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -679,7 +679,7 @@ class LinuxBridge(NetworkPlugin):
             return {'error': 11}
         cp_ip = self.__get_cp_ip(cp_id)
         if cp_ip == '':
-            self.logger.error('remove_floating_ip()', 'Connection point {} as not IP'.format(ip_id))
+            self.logger.error('remove_floating_ip()', 'Connection point {} has no IP'.format(ip_id))
             return {'error': 11}
         cmd = 'sudo iptables -t nat -D PREROUTING -d {} -j DNAT --to {}'.format(rec['vface'], cp_ip)
         self.call_os_plugin_function('execute_command',{'command':cmd,'blocking':True, 'external':True})
@@ -701,7 +701,7 @@ class LinuxBridge(NetworkPlugin):
             intfs = i['interfaces']
             for intf in intfs:
                 if intf.get('cp_id') is not None and intf.get('cp_id') != '':
-                    if intf.get('cp_id') == cp_rec['cp_uuid']:
+                    if intf.get('cp_id') == cp_rec['uuid']:
                         i_name = intf['vintf_name']
                         hv_info = i['hypervisor_info']
                         if len(hv_info) > 0:

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -181,6 +181,7 @@ class LinuxBridge(NetworkPlugin):
 
 
     def get_address(self, mac_address):
+        self.logger.info('get_address()', 'Linux Bridge Plugin - Getting IP address for  {}'.format(mac_address))
 
         # LEASE FILE FORMAT
         # 1560518377 00:16:3e:5e:a8:fa 192.168.123.13 holy-gar 01:00:16:3e:5e:a8:fa
@@ -197,8 +198,10 @@ class LinuxBridge(NetworkPlugin):
                     for l in res:
                         tok = l.split(' ')
                         if tok[1] == mac_address:
+                            self.logger.info('get_address()', 'Linux Bridge Plugin - IP address for {} is '.format(mac_address, tok[2]))
                             return {'result': tok[2]}
-            continue
+
+        self.logger.info('get_address()', 'Linux Bridge Plugin - Unable to get IP address for {} '.format(mac_address))
         return {'result': ''}
 
 

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -648,6 +648,10 @@ class LinuxBridge(NetworkPlugin):
         return {'result': rec}
 
     def assign_floating_ip(self, ip_id, cp_id):
+        # fagent: [ERROR] [FOS-AGENT] - EV-ASSOC-FLOATING-IP - EXCEPTION: (Failure
+        # "[YAS]:
+        # EVAL on /alfos/a2d358aa-af2b-42cb-8d23-a89e88b97e5c/network_managers/d42b4163-af35-423a-acb4-a228290cf0be/exec/assign_floating_ip?(ip_id=c02eea4f-6f35-4a87-b8bb-b9ba617e8214;cp_id=a47a8819-72e5-4b4e-86fd-fc30c9fda68b):
+        # ErrNo 400")
         self.logger.info('assign_floating_ip()', 'Assigning floating IP {} to {}'.format(ip_id, cp_id))
         rec = self.connector.loc.actual.get_node_floating_ip(self.node, self.uuid, ip_id)
         if rec is None:
@@ -689,6 +693,7 @@ class LinuxBridge(NetworkPlugin):
 
     def __get_cp_ip(self, cp_id):
         cp_rec = self.connector.loc.actual.get_node_port(self.node, self.uuid, cp_id)
+        self.logger.info('__get_cp_ip()', 'Get connection point IP for {} Record: {}'.format(cp_id, cp_rec))
         fdus = self.connector.loc.actual.get_node_all_fdus_instances(self.node)
         cp_ip = ''
         for i in fdus:
@@ -700,6 +705,7 @@ class LinuxBridge(NetworkPlugin):
                         hv_info = i['hypervisor_info']
                         if len(hv_info) > 0:
                             cp_ip = hv_info['network'][i_name]['addresses'][0]['address']
+        self.logger.info('__get_cp_ip()', 'IP for {} -> {}'.format(cp_id, cp_ip))
         return cp_ip
 
     def __cird2block(self, cird):

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -695,11 +695,11 @@ class LinuxBridge(NetworkPlugin):
             intfs = i['interfaces']
             for intf in intfs:
                 if intf.get('cp_id') is not None and intf.get('cp_id') != '':
-                    if intf.get('cp_id') == cp_id:
+                    if intf.get('cp_id') == cp_rec['cp_uuid']:
                         i_name = intf['vintf_name']
                         hv_info = i['hypervisor_info']
                         if len(hv_info) > 0:
-                            cp_id = hv_info['network']['i_name']['addresses'][0]['address']
+                            cp_ip = hv_info['network'][i_name]['addresses'][0]['address']
         return cp_ip
 
     def __cird2block(self, cird):

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -697,6 +697,7 @@ class LinuxBridge(NetworkPlugin):
         fdus = self.connector.loc.actual.get_node_all_fdus_instances(self.node)
         cp_ip = ''
         for i in fdus:
+            self.logger.info('__get_cp_ip()', 'Scanning FDUs Record: {}'.format(i))
             intfs = i['interfaces']
             for intf in intfs:
                 if intf.get('cp_id') is not None and intf.get('cp_id') != '':

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -403,10 +403,12 @@ let agent verbose_flag debug_flag configuration custom_uuid =
         >>= fun _ ->
         let eval_res = FAgentTypes.{result = Some (JSON.of_string (FTypes.string_of_floating_ip floating)) ; error=None} in
         Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
-      |  None -> let eval_res = FAgentTypes.{result = None ; error=Some 11} in
+      |  None -> let eval_res = FAgentTypes.{result = None ; error=Some 33} in
+        let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-ASSOC-FLOATING-IP - EVAL RETURNED NONE") in
         Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
-    | _ -> let eval_res = FAgentTypes.{result = None ; error=Some 11} in
+    | exn -> let eval_res = FAgentTypes.{result = None ; error=Some 22} in
+      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-ASSOC-FLOATING-IP - EXCEPTION: %s" (Printexc.to_string exn)) in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   let eval_remove_floating_ip self (props:Apero.properties) =
@@ -430,10 +432,12 @@ let agent verbose_flag debug_flag configuration custom_uuid =
         >>= fun _ ->
         let eval_res = FAgentTypes.{result = Some (JSON.of_string (FTypes.string_of_floating_ip floating)) ; error=None} in
         Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
-      |  None -> let eval_res = FAgentTypes.{result = None ; error=Some 11} in
+      |  None -> let eval_res = FAgentTypes.{result = None ; error=Some 33} in
+        let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-REMOVE-FLOATING-IP - EVAL RETURNED NONE") in
         Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
-    | _ -> let eval_res = FAgentTypes.{result = None ; error=Some 11} in
+    | exn -> let eval_res = FAgentTypes.{result = None ; error=Some 22} in
+      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-REMOVE-FLOATING-IP - EXCEPTION: %s" (Printexc.to_string exn)) in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   (* Listeners *)

--- a/src/api/python/api/fog05/fimapi.py
+++ b/src/api/python/api/fog05/fimapi.py
@@ -380,6 +380,13 @@ class FIMAPI(object):
         def delete_floating_ip(self, nodeid, ip_id):
             return self.connector.glob.actual.remove_node_floatingip(self.sysid, self.tenantid, nodeid, ip_id)
 
+
+        def assign_floating_ip(self, nodeid, ip_id, cp_id):
+            return self.connector.glob.actual.assign_node_floating_ip(self.sysid, self.tenantid, nodeid, ip_id, cp_id)
+
+        def retain_floating_ip(self, nodeid, ip_id, cp_id):
+            return self.connector.glob.actual.retain_node_floating_ip(self.sysid, self.tenantid, nodeid, ip_id, cp_id)
+
         def list(self):
             '''
 

--- a/src/api/python/api/fog05/yaks_connector.py
+++ b/src/api/python/api/fog05/yaks_connector.py
@@ -1223,7 +1223,7 @@ class LAD(object):
         res = self.ws.get(p)
         if len(res) == 0:
             return []
-        return list(map (lambda x: json.loads(x[1]), res))
+        return list(map (lambda x: json.loads(x[1].get_value()), res))
 
     def add_node_image(self, nodeid, pluginid, imgid, imginfo):
         p = self.get_node_image_info_path(nodeid, pluginid, imgid)

--- a/src/api/python/api/fog05/yaks_connector.py
+++ b/src/api/python/api/fog05/yaks_connector.py
@@ -1066,7 +1066,7 @@ class LAD(object):
             nodeid, nm_uuid, func_name, parameters)
         res = self.ws.eval(s)
         if len(res) == 0:
-            raise ValueError('Empty data on exec_os_eval')
+            raise ValueError('Empty data on exec_nw_eval')
         else:
             return json.loads(res[0][1].get_value())
 

--- a/src/api/python/api/fog05/yaks_connector.py
+++ b/src/api/python/api/fog05/yaks_connector.py
@@ -231,8 +231,8 @@ class GAD(object):
         return '('+b+')'
 
     def get_agent_exec_path(self, sysid, tenantid, nodeid, func_name):
-        return Constants.create_path([self.prefix, sysid, "tenants",
-        tenantid, "nodes", nodeid, 'agent', 'exec', func_name])
+        return Constants.create_path([self.prefix, sysid, 'tenants',
+        tenantid, 'nodes', nodeid, 'agent', 'exec', func_name])
 
     def get_agent_exec_path_with_params(self, sysid, tenantid, nodeid, func_name, params):
         if len(params) > 0:
@@ -240,8 +240,8 @@ class GAD(object):
             f = func_name + '?' + p
         else:
             f = func_name
-        return Constants.create_path([self.prefix, sysid, "tenants",
-        tenantid, "nodes", nodeid, 'agent', 'exec',f])
+        return Constants.create_path([self.prefix, sysid, 'tenants',
+        tenantid, 'nodes', nodeid, 'agent', 'exec',f])
 
 
     def extract_userid_from_path(self, path):
@@ -744,41 +744,61 @@ class GAD(object):
     # Agent Evals
 
     def add_node_port_to_network(self, sysid, tenantid,  nodeid, portid, network_id):
-        fname = "add_port_to_network"
+        fname = 'add_port_to_network'
         params = {'cp_uuid': portid, 'network_uuid':network_id}
         s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
         res = self.ws.eval(s)
         if len(res) == 0:
-            raise ValueError('Empty data on exec_os_eval')
+            raise ValueError('Empty data on exec_agent_eval')
         else:
             return json.loads(res[0][1].get_value())
 
     def remove_node_port_from_network(self, sysid, tenantid, nodeid, portid):
-        fname = "remove_port_from_network"
+        fname = 'remove_port_from_network'
         params = {'cp_uuid': portid}
         s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
         res = self.ws.eval(s)
         if len(res) == 0:
-            raise ValueError('Empty data on exec_os_eval')
+            raise ValueError('Empty data on exec_agent_eval')
         else:
             return json.loads(res[0][1].get_value())
 
     def add_node_floatingip(self, sysid, tenantid, nodeid):
-        fname = "create_floating_ip"
+        fname = 'create_floating_ip'
         s = self.get_agent_exec_path(sysid, tenantid, nodeid, fname)
         res = self.ws.eval(s)
         if len(res) == 0:
-            raise ValueError('Empty data on exec_os_eval')
+            raise ValueError('Empty data on exec_agent_eval')
         else:
             return json.loads(res[0][1].get_value())
 
     def remove_node_floatingip(self, sysid, tenantid, nodeid, ipid):
-        fname = "delete_floating_ip"
+        fname = 'delete_floating_ip'
         params = {'floating_uuid': ipid}
         s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
         res = self.ws.eval(s)
         if len(res) == 0:
-            raise ValueError('Empty data on exec_os_eval')
+            raise ValueError('Empty data on exec_agent_eval')
+        else:
+            return json.loads(res[0][1].get_value())
+
+    def assign_node_floating_ip(self, sysid, tenantid, nodeid, ipid, cpid):
+        fname = 'assign_floating_ip'
+        params = {'floating_uuid': ipid, 'cp_uuid': cpid}
+        s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
+        res = self.ws.eval(s)
+        if len(res) == 0:
+            raise ValueError('Empty data on exec_agent_eval')
+        else:
+            return json.loads(res[0][1].get_value())
+
+    def retain_node_floating_ip(self, sysid, tenantid, nodeid, ipid, cpid):
+        fname = 'remove_floating_ip'
+        params = {'floating_uuid': ipid, 'cp_uuid': cpid}
+        s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
+        res = self.ws.eval(s)
+        if len(res) == 0:
+            raise ValueError('Empty data on exec_agent_eval')
         else:
             return json.loads(res[0][1].get_value())
 
@@ -878,7 +898,7 @@ class LAD(object):
 
     def get_node_all_fdus_instances_selector(self, nodeid):
         return Constants.create_path(
-            [self.prefix, nodeid, 'runtimes', "*", 'fdu', '*',
+            [self.prefix, nodeid, 'runtimes', '*', 'fdu', '*',
             'instances','*','info'])
 
     def get_node_image_info_path(self, nodeid, pluginid, imgid):


### PR DESCRIPTION
This solves #124 
The monitoring information can be retrieved by `instance_info` API
and they will be available under the `hypervisor_info` key

Example:
```
a.fdu.instance_info('a7335489-44b8-41db-96c3-bc44944016ed')
{'fdu_uuid': '1b526aa7-408f-4d63-b58c-9e2dfd9451ed', 'node': 'a2d358aa-af2b-42cb-8d23-a89e88b97e5c', 'uuid': 'a7335489-44b8-41db-96c3-bc44944016ed', 'status': 'RUN', 'interfaces': [{'vintf_name': 'eth0', 'status': 'CREATE', 'if_type': 'BRIDGED', 'mac_address': 'be:ef:be:ef:00:02', 'phy_face': 'lxdbr0'}], 'connection_points': [], 'hypervisor_info': {'network': {'eth0': {'hwaddr': 'be:ef:be:ef:00:02', 'addresses': [{'address': '192.168.122.100'}]}}, 'cpu': {'usage': 2148560701}, 'memory': {'usage': 7041024, 'usage_peak': 9412608, 'swap_usage': 0, 'swap_usage_peak': 0}}, 'accelerators': {'fpga': [], 'gpu': []}, 'io_ports': []}
```