### PR TITLE
Virtual Router Implementation

### DIFF
--- a/fos-plugins/linux/linux_plugin
+++ b/fos-plugins/linux/linux_plugin
@@ -300,9 +300,9 @@ class Linux(OSPlugin):
 
     def execute_command(self, command, blocking=False, external=False):
         if isinstance(blocking, str):
-            root = bool(distutils.util.strtobool(blocking))
+            blocking = bool(distutils.util.strtobool(blocking))
         if isinstance(external, str):
-            root = bool(distutils.util.strtobool(external))
+            external = bool(distutils.util.strtobool(external))
         try:
             self.logger.info('execute_command()', 'OS Plugin executing command {}'.format(command))
             r = ''

--- a/fos-plugins/linuxbridge/Makefile
+++ b/fos-plugins/linuxbridge/Makefile
@@ -18,6 +18,8 @@ else
 	sudo cp ../linuxbridge/linuxbridge_plugin /etc/fos/plugins/linuxbridge/
 	sudo cp ../linuxbridge/README.md /etc/fos/plugins/linuxbridge/
 	sudo ln -sf /etc/fos/plugins/linuxbridge/linuxbridge_plugin /usr/bin/fos_linuxbridge
+	sudo cp ../linuxbridge/get_face_address /etc/fos/plugins/linuxbridge/get_face_address
+	sudo ln -sf /etc/fos/plugins/linuxbridge/get_face_address /usr/bin/fos_get_address
 endif
 	sudo cp /etc/fos/plugins/linuxbridge/fos_linuxbridge.service /lib/systemd/system/
 	sudo sh -c "echo $(UUID) | xargs -i  jq  '.configuration.nodeid = \"{}\"' /etc/fos/plugins/linuxbridge/linuxbridge_plugin.json > /tmp/linuxbridge_plugin.tmp && mv /tmp/linuxbridge_plugin.tmp /etc/fos/plugins/linuxbridge/linuxbridge_plugin.json"

--- a/fos-plugins/linuxbridge/get_face_address
+++ b/fos-plugins/linuxbridge/get_face_address
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2014,2018 ADLINK Technology Inc.
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors: Gabriele Baldoni, ADLINK Technology Inc. - LinuxBridge plugin
+
+import sys
+import netifaces
+import socket
+
+
+def get_net_size(netmask):
+    binary_str = ''
+    for octet in netmask:
+        binary_str += bin(int(octet))[2:].zfill(8)
+    return str(len(binary_str.rstrip('0')))
+
+def ip_mask_to_cird(ip, mask):
+
+    try:
+        socket.inet_aton(ip)
+        socket.inet_aton(mask)
+    except:
+        return "0.0.0.0/0"
+
+    ip = ip.split('.')
+    mask = mask.split('.')
+    net_start = [str(int(ip[x])) for x in range(0, 4)]
+    return '.'.join(net_start) + '/' + get_net_size(mask)
+
+def main(face):
+    try:
+        addr = netifaces.ifaddresses(face)[2][0]['addr']
+        mask = netifaces.ifaddresses(face)[2][0]['netmask']
+        addr = ip_mask_to_cird(addr, mask)
+
+    except:
+        addr = '0.0.0.0/0'
+    print(addr)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1])

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -510,7 +510,7 @@ class LinuxBridge(NetworkPlugin):
 
                 self.logger.info('delete_router()', 'Removed External Face {}'.format(p['faces'][0]))
 
-            elif p['port'] == 'INTERNAL':
+            elif p['port_type'] == 'INTERNAL':
                 self.logger.info('delete_router()', 'Removing Internal Face {}'.format(p['faces'][0]))
 
                 net_record = self.networks.get(p['pair_id'])

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -423,7 +423,9 @@ class LinuxBridge(NetworkPlugin):
 
                     cmd_get_address = 'sudo ip netns exec {} fos_get_address {}'.format(record['router_ns'], p['faces'][0])
 
-                    addr = self.call_os_plugin_function('execute_command', {'command':cmd_get_address, 'blocking':True, 'external':False})['record']
+                    addr = self.call_os_plugin_function('execute_command', {'command':cmd_get_address, 'blocking':True, 'external':False})
+                    self.logger.info('create_router()', 'Returing: {}'.format(addr))
+                    addr = addr[0]['result']
 
                     p.update({'ip_address':addr})
                 else:

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -84,6 +84,7 @@ class LinuxBridge(NetworkPlugin):
         self.intfs = {}
         self.ports = {}
         self.bridges = {}
+        self.routers = {}
 
         signal.signal(signal.SIGINT, self.__catch_signal)
         signal.signal(signal.SIGTERM, self.__catch_signal)
@@ -369,6 +370,163 @@ class LinuxBridge(NetworkPlugin):
         self.ports.pop(cp_id)
         self.connector.loc.actual.remove_node_port(self.node, self.uuid, cp_id)
 
+
+    def create_router(self, record):
+        router_id = record.get('uuid')
+        self.logger.info('create_router()', 'Creating {} Record: {}'.format(router_id, record))
+        # {
+        #   'uuid':'12345678-1234-1234-1234-123456789012',
+        #   'state':'CREATE',
+        #   'router_ns': 'r-12345678-ns',
+        #   'nodeid': ''12345678-1234-1234-1234-123456789012',
+        #   'ports': [
+        #       {
+        #          'port_type':'EXTERNAL',
+        #          'ext_face':'ens2',
+        #          'ip_address':'',
+        #          'faces':['r-12345678-e0']
+        #       },
+        #       {
+        #          'port_type':'INTERNAL',
+        #          'faces': [ 'r-12345678-e1-i', 'r-12345678-e1-e'],
+        #          'ip_address': '192.168.123.1/24',
+        #          'pair_id': '12345678-1234-1234-1234-123456789012'
+        #       }
+        #   ]
+        # }
+
+        self.logger.info('create_router()', 'Creating Router NS: {}'.format(record['router_ns']))
+        cmd_new_ns = 'sudo ip netns add {}'.format(record['router_ns'])
+        cmd_ns_forwarding = 'sudo ip netns exec {} sysctl -w net.ipv4.ip_forward=1'.format(record['router_ns'])
+        self.call_os_plugin_function('execute_command', {'command':cmd_new_ns, 'blocking':True, 'external':True})
+        self.call_os_plugin_function('execute_command', {'command':cmd_ns_forwarding, 'blocking':True, 'external':True})
+        ext_face = ''
+        for p in record['ports']:
+
+            if p['port_type'] == 'EXTERNAL':
+                cmd_add_macvlan = 'sudo ip link add {} link {} type macvlan mode vepa'.format(p['faces'][0], p['ext_face'])
+                cmd_port_to_ns = 'sudo ip link set {} netns {}'.format(p['faces'][0], record['router_ns'])
+                cmd_port_up = 'sudo ip netns exec {} ip link set {} up'.format(record['router_ns'], p['faces'][0])
+
+                self.logger.info('create_router()', 'Creating EXTERNAL PORT: {} and assiging to router NS {}'.format(p['faces'][0], record['router_ns']))
+                self.call_os_plugin_function('execute_command', {'command':cmd_add_macvlan, 'blocking':True, 'external':True})
+                self.call_os_plugin_function('execute_command', {'command':cmd_port_to_ns, 'blocking':True, 'external':True})
+                self.call_os_plugin_function('execute_command', {'command':cmd_port_up, 'blocking':True, 'external':True})
+                if p['ip_address'] == '':
+
+                    self.logger.info('create_router()', 'Asking address for face: {}'.format(p['faces'][0]))
+
+                    cmd_dhcp_client = 'sudo ip netns exec {} dhclient {}'.format(record['router_ns'], p['faces'][0])
+                    self.call_os_plugin_function('execute_command', {'command':cmd_dhcp_client, 'blocking':True, 'external':True})
+
+                    cmd_get_address = 'sudo ip netns exec {} fos_get_address {}'.format(record['router_ns'], p['faces'][0])
+
+                    addr = self.call_os_plugin_function('execute_command', {'command':cmd_get_address, 'blocking':True, 'external':False})['record']
+
+                    p.update({'ip_address':addr})
+                else:
+                    self.logger.info('create_router()', 'Assing {} address for face: {}'.format(p['ip_address'], p['faces'][0]))
+                    cmd_add_addr = 'sudo ip netns exec {} ip addr add {} dev {}'.format(record['router_ns'], p['ip_address'], p['faces'][0])
+                    self.call_os_plugin_function('execute_command', {'command':cmd_add_addr, 'blocking':True, 'external':True})
+                self.logger.info('create_router()', 'Router EXTERNAL PORT Created: {}'.format(p['faces'][0]))
+                ext_face = p['faces'][0]
+
+            elif p['port_type'] == 'INTERNAL':
+                self.logger.info('create_router()', 'Creating INTERNAL PORT: {}<->{}'.format(p['faces'][0], p['faces'][1]))
+
+                cmd_veth_pair = 'sudo ip link add {} type veth peer name {}'.format(p['faces'][0], p['faces'][1])
+                cmd_i_face_to_ns = 'sudo ip link set {} netns {}'.format(p['faces'][0], record['router_ns'])
+                cmd_i_face_up = 'sudo ip netns exec {} ip link set {} up'.format(record['router_ns'], p['faces'][0])
+
+                self.call_os_plugin_function('execute_command', {'command':cmd_veth_pair, 'blocking':True, 'external':True})
+                self.call_os_plugin_function('execute_command', {'command':cmd_i_face_to_ns, 'blocking':True, 'external':True})
+                self.call_os_plugin_function('execute_command', {'command':cmd_i_face_up, 'blocking':True, 'external':True})
+
+                net_record = self.networks.get(p['pair_id'])
+                net_ns = net_record['properties']['net_ns']
+                net_dev = net_record['properties']['virtual_device']
+
+                cmd_e_face_to_ns = 'sudo ip link set {} netns {}'.format(p['faces'][1], net_ns)
+                cmd_e_face_up = 'sudo ip netns exec {} ip link set {} up'.format(net_ns, p['faces'][1])
+                cmd_e_face_master = 'sudo ip netns exec {} ip link set {} master {}'.format(net_ns, p['faces'][1], net_dev)
+
+                self.call_os_plugin_function('execute_command', {'command':cmd_e_face_to_ns, 'blocking':True, 'external':True})
+                self.call_os_plugin_function('execute_command', {'command':cmd_e_face_up, 'blocking':True, 'external':True})
+                self.call_os_plugin_function('execute_command', {'command':cmd_e_face_master, 'blocking':True, 'external':True})
+
+                if p['ip_address'] == '':
+
+                    self.logger.info('create_router()', 'Asking address for face: {}'.format(p['faces'][0]))
+                    cmd_dhcp_client = 'sudo ip netns exec {} dhclient {}'.format(record['router_ns'],p['faces'][0])
+                    self.call_os_plugin_function('execute_command', {'command':cmd_dhcp_client, 'blocking':True, 'external':True})
+
+                    cmd_get_address = 'sudo ip netns exec {} fos_get_address {}'.format(record['router_ns'], p['faces'][0])
+
+                    addr = self.call_os_plugin_function('execute_command', {'command':cmd_get_address, 'blocking':True, 'external':False})['record']
+
+                    p.update({'ip_address':addr})
+                else:
+                    self.logger.info('create_router()', 'Assing {} address for face: {}'.format(p['ip_address'], p['faces'][0]))
+                    cmd_add_addr = 'sudo ip netns exec {} ip addr add {} dev {}'.format(record['router_ns'], p['ip_address'], p['faces'][0])
+                    self.call_os_plugin_function('execute_command', {'command':cmd_add_addr, 'blocking':True, 'external':True})
+
+                self.logger.info('create_router()', 'Setting iptables rules...')
+
+                cmd_iptables_nat = 'sudo ip netns exec {} iptables -t nat -A POSTROUTING -s {} -o {} -j MASQUERADE'.format(record['router_ns'], p['ip_address'], ext_face)
+                cmd_iptables_forward_in = 'sudo ip netns exec {} iptables -A FORWARD -i {} -o {} -j ACCEPT'.format(record['router_ns'], ext_face, p['faces'][0])
+                cmd_iptables_forward_out = 'sudo ip netns exec {} iptables -A FORWARD -o {} -i {} -j ACCEPT'.format(record['router_ns'], ext_face, p['faces'][0])
+
+                self.call_os_plugin_function('execute_command', {'command':cmd_iptables_nat, 'blocking':True, 'external':True})
+                self.call_os_plugin_function('execute_command', {'command':cmd_iptables_forward_in, 'blocking':True, 'external':True})
+                self.call_os_plugin_function('execute_command', {'command':cmd_iptables_forward_out, 'blocking':True, 'external':True})
+
+
+            else:
+                self.logger.error('create_router()', 'Router port_type is not recognized: {}'.format(p['port_type']))
+
+        self.logger.info('create_router()', 'Router {} created!'.format(router_id))
+        self.routers.update({router_id: record})
+        self.connector.loc.actual.add_node_router(self.node, self.uuid, router_id, record)
+
+
+    def delete_router(self, router_id):
+        router_info = self.routers.get(router_id)
+        if router_info is None:
+            self.logger.error('delete_router()','Router {} does not exist'.format(router_id))
+            return False
+        self.logger.info('delete_router()', 'Removing Router {}'.format(router_id))
+        for p in router_info['faces']:
+            if p['port_type'] == 'EXTERNAL':
+                self.logger.info('delete_router()', 'Removing External Face {}'.format(p['faces'][0]))
+                cmd_remove_face = 'sudo ip netns exec {} ip link del {}'.format(router_info['router_ns'], p['faces'][0])
+
+                self.call_os_plugin_function('execute_command', {'command':cmd_remove_face, 'blocking':True, 'external':True})
+
+                self.logger.info('delete_router()', 'Removed External Face {}'.format(p['faces'][0]))
+
+            elif p['port'] == 'INTERNAL':
+                self.logger.info('delete_router()', 'Removing Internal Face {}'.format(p['faces'][0]))
+
+                net_record = self.networks.get(p['pair_id'])
+                net_ns = net_record['properties']['net_ns']
+
+                cmd_remove_face = 'sudo ip netns exec {} ip link del {}'.format(net_ns, p['faces'][1])
+
+                self.call_os_plugin_function('execute_command', {'command':cmd_remove_face, 'blocking':True, 'external':True})
+
+                self.logger.info('delete_router()', 'Removed Internal Face {}'.format(p['faces'][0]))
+            else:
+                self.logger.error('create_router()', 'Router port_type is not recognized: {}'.format(p['port_type']))
+
+
+
+        cmd_ns_rem = 'sudo ip netns del {}'.format(router_info['router_ns'])
+        self.call_os_plugin_function('execute_command', {'command':cmd_ns_rem, 'blocking':True, 'external':True})
+
+
+        self.logger.info('delete_router()', 'Router {} deleted'.format(router_id))
+        self.routers.pop(router_id)
+        self.connector.loc.actual.remove_node_router(self.node, self.uuid, router_id)
 
 
     # network_name, net_uuid, ip_range=None, has_dhcp=False, gateway=None,
@@ -786,6 +944,20 @@ class LinuxBridge(NetworkPlugin):
             self.create_port(port_info)
         else:
             self.logger.info('__port_observer()', 'Linux Bridge Plugin - Action not recognized : {}'.format(action))
+
+
+    def __router_observer(self, router_info):
+        self.logger.info('__router_observer()', 'Linux Bridge Plugin - New Action of a Router - Router Info: {}'.format(router_info))
+        action = router_info.get('state')
+        router_uuid = router_info.get('uuid')
+        if action == 'DESTROY':
+            self.logger.info('__router_observer()', 'Linux Bridge Plugin - This is a remove for : {}'.format(router_info))
+            self.delete_router(router_uuid)
+        elif action == 'CREATE':
+            self.logger.info('__router_observer()', 'Linux Bridge Plugin - This is a add for : {}'.format(router_info))
+            self.create_router(router_info)
+        else:
+            self.logger.info('__router_observer()', 'Linux Bridge Plugin - Action not recognized : {}'.format(action))
 
 
     def __generate_interface_create_script(self, internal_name, external_name, name):

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -564,7 +564,7 @@ class LinuxBridge(NetworkPlugin):
         if ports[-1]['port_type'] == 'INTERNAL':
             port_id = int(ports[-1]['faces'][0][12:-2])+1
         else:
-            port_id = int(ports[-1]['faces'][0][11:])+1
+            port_id = int(ports[-1]['faces'][0][12:])+1
 
 
         if port_type.upper() == 'EXTERNAL':

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -550,13 +550,21 @@ class LinuxBridge(NetworkPlugin):
         if record is None:
             self.logger.error('add_port_to_router()','Router {} does not exist'.format(router_id))
             return {'error': 404}
-        port_id = len(record['ports'])
+
 
         # Sorting ports to have always the same order
         ports = sorted(record['ports'], key=lambda k: k['port_type']+k['faces'][0])
         record.update({'ports': ports})
 
+
         ext_face = ports[0]['faces'][0]
+
+        # getting next port id
+        if ports[-1]['port_type'] == 'INTERNAL':
+            port_id = int(ports[-1]['faces'][0][12:-2])
+        else:
+            port_id = int(ports[-1]['faces'][0][11:])
+
 
         if port_type.upper() == 'EXTERNAL':
             pass

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -551,15 +551,16 @@ class LinuxBridge(NetworkPlugin):
             self.logger.error('add_port_to_router()','Router {} does not exist'.format(router_id))
             return {'error': 404}
 
-
+        self.logger.info('add_port_to_router()', 'Sorting ports')
         # Sorting ports to have always the same order
         ports = sorted(record['ports'], key=lambda k: k['port_type']+k['faces'][0])
         record.update({'ports': ports})
 
-
+        self.logger.info('add_port_to_router()', 'Selecting external face ports')
         ext_face = ports[0]['faces'][0]
 
         # getting next port id
+        self.logger.info('add_port_to_router()', 'Selecting new port id')
         if ports[-1]['port_type'] == 'INTERNAL':
             port_id = int(ports[-1]['faces'][0][12:-2])+1
         else:

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -184,6 +184,8 @@ class LinuxBridge(NetworkPlugin):
             self.delete_virtual_network(k)
         for k in list(self.bridges.keys()):
             self.delete_virtual_bridge(k)
+        for k in list(self.routers.keys()):
+            self.delete_router(k)
 
 
     def get_overlay_face(self):

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -561,9 +561,9 @@ class LinuxBridge(NetworkPlugin):
 
         # getting next port id
         if ports[-1]['port_type'] == 'INTERNAL':
-            port_id = int(ports[-1]['faces'][0][12:-2])
+            port_id = int(ports[-1]['faces'][0][12:-2])+1
         else:
-            port_id = int(ports[-1]['faces'][0][11:])
+            port_id = int(ports[-1]['faces'][0][11:])+1
 
 
         if port_type.upper() == 'EXTERNAL':

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -501,7 +501,7 @@ class LinuxBridge(NetworkPlugin):
             self.logger.error('delete_router()','Router {} does not exist'.format(router_id))
             return False
         self.logger.info('delete_router()', 'Removing Router {}'.format(router_id))
-        for p in router_info['faces']:
+        for p in router_info['ports']:
             if p['port_type'] == 'EXTERNAL':
                 self.logger.info('delete_router()', 'Removing External Face {}'.format(p['faces'][0]))
                 cmd_remove_face = 'sudo ip netns exec {} ip link del {}'.format(router_info['router_ns'], p['faces'][0])

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -157,6 +157,8 @@ class LinuxBridge(NetworkPlugin):
             self.node, self.uuid, self.__net_observer)
         self.connector.loc.desired.observe_node_ports(
             self.node, self.uuid, self.__port_observer)
+        self.connector.loc.desired.observe_node_routers(
+            self.node, self.uuid, self.__router_observer)
         self.manifest.update({'pid': self.pid})
         self.manifest.update({'status': 'running'})
         self.connector.loc.actual.add_node_plugin(
@@ -444,7 +446,7 @@ class LinuxBridge(NetworkPlugin):
 
                 net_record = self.networks.get(p['pair_id'])
                 net_ns = net_record['properties']['net_ns']
-                net_dev = net_record['properties']['virtual_device']
+                net_dev = net_record['properties']['virtual_device'] + '-ns'
 
                 cmd_e_face_to_ns = 'sudo ip link set {} netns {}'.format(p['faces'][1], net_ns)
                 cmd_e_face_up = 'sudo ip netns exec {} ip link set {} up'.format(net_ns, p['faces'][1])

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -404,7 +404,14 @@ class LinuxBridge(NetworkPlugin):
         cmd_ns_forwarding = 'sudo ip netns exec {} sysctl -w net.ipv4.ip_forward=1'.format(record['router_ns'])
         self.call_os_plugin_function('execute_command', {'command':cmd_new_ns, 'blocking':True, 'external':True})
         self.call_os_plugin_function('execute_command', {'command':cmd_ns_forwarding, 'blocking':True, 'external':True})
-        ext_face = ''
+
+        # Sorting ports to have always the same order
+        ports = sorted(record['ports'], key=lambda k: k['port_type']+k['faces'][0])
+        record.update({'ports': ports})
+
+        ext_face = ports[0]['faces'][0]
+
+
         for p in record['ports']:
 
             if p['port_type'] == 'EXTERNAL':
@@ -435,7 +442,7 @@ class LinuxBridge(NetworkPlugin):
                     cmd_add_addr = 'sudo ip netns exec {} ip addr add {} dev {}'.format(record['router_ns'], p['ip_address'], p['faces'][0])
                     self.call_os_plugin_function('execute_command', {'command':cmd_add_addr, 'blocking':True, 'external':True})
                 self.logger.info('create_router()', 'Router EXTERNAL PORT Created: {}'.format(p['faces'][0]))
-                ext_face = p['faces'][0]
+
 
             elif p['port_type'] == 'INTERNAL':
                 self.logger.info('create_router()', 'Creating INTERNAL PORT: {}<->{}'.format(p['faces'][0], p['faces'][1]))
@@ -468,9 +475,9 @@ class LinuxBridge(NetworkPlugin):
 
                     cmd_get_address = 'sudo ip netns exec {} fos_get_address {}'.format(record['router_ns'], p['faces'][0])
 
-                    addr = self.call_os_plugin_function('execute_command', {'command':cmd_get_address, 'blocking':True, 'external':False})['record']
+                    addr = self.call_os_plugin_function('execute_command', {'command':cmd_get_address, 'blocking':True, 'external':False})
 
-                    p.update({'ip_address':addr})
+                    p.update({'ip_address':addr.strip()})
                 else:
                     self.logger.info('create_router()', 'Assing {} address for face: {}'.format(p['ip_address'], p['faces'][0]))
                     cmd_add_addr = 'sudo ip netns exec {} ip addr add {} dev {}'.format(record['router_ns'], p['ip_address'], p['faces'][0])
@@ -533,6 +540,138 @@ class LinuxBridge(NetworkPlugin):
         self.logger.info('delete_router()', 'Router {} deleted'.format(router_id))
         self.routers.pop(router_id)
         self.connector.loc.actual.remove_node_router(self.node, self.uuid, router_id)
+
+    def add_port_to_router(self, router_id, port_type, vnet_id=None, ip_address=None):
+        self.logger.info('add_port_to_router()', 'Adding port to router {}'.format(router_id))
+        record = self.routers.get(router_id)
+
+        if record is None:
+            self.logger.error('add_port_to_router()','Router {} does not exist'.format(router_id))
+            return {'error': 404}
+        port_id = len(record['ports'])
+
+        # Sorting ports to have always the same order
+        ports = sorted(record['ports'], key=lambda k: k['port_type']+k['faces'][0])
+        record.update({'ports': ports})
+
+        ext_face = ports[0]['faces'][0]
+
+        if port_type.upper() == 'EXTERNAL':
+            pass
+        elif port_type.upper() == 'INTERNAL' and vnet_id is not None:
+            self.logger.info('add_port_to_router()', 'Adding INTERNAL port to router {}'.format(router_id))
+
+            net_record = self.networks.get(vnet_id)
+            net_ns = net_record['properties']['net_ns']
+            net_dev = net_record['properties']['virtual_device'] + '-ns'
+
+            iface = 'r-{}-e{}-i'.format(router_id.split('-')[0], port_id)
+            eface = 'r-{}-e{}-e'.format(router_id.split('-')[0], port_id)
+
+            cmd_veth_pair = 'sudo ip link add {} type veth peer name {}'.format(iface, eface)
+            cmd_i_face_to_ns = 'sudo ip link set {} netns {}'.format(iface, record['router_ns'])
+            cmd_i_face_up = 'sudo ip netns exec {} ip link set {} up'.format(record['router_ns'], iface)
+
+            self.call_os_plugin_function('execute_command', {'command':cmd_veth_pair, 'blocking':True, 'external':True})
+            self.call_os_plugin_function('execute_command', {'command':cmd_i_face_to_ns, 'blocking':True, 'external':True})
+            self.call_os_plugin_function('execute_command', {'command':cmd_i_face_up, 'blocking':True, 'external':True})
+
+            cmd_e_face_to_ns = 'sudo ip link set {} netns {}'.format(eface, net_ns)
+            cmd_e_face_up = 'sudo ip netns exec {} ip link set {} up'.format(net_ns, eface)
+            cmd_e_face_master = 'sudo ip netns exec {} ip link set {} master {}'.format(net_ns, eface, net_dev)
+
+            self.call_os_plugin_function('execute_command', {'command':cmd_e_face_to_ns, 'blocking':True, 'external':True})
+            self.call_os_plugin_function('execute_command', {'command':cmd_e_face_up, 'blocking':True, 'external':True})
+            self.call_os_plugin_function('execute_command', {'command':cmd_e_face_master, 'blocking':True, 'external':True})
+
+            port_record = {
+                'port_type':port_type.upper(),
+                'faces':[iface, eface],
+                'pair_id': vnet_id,
+            }
+
+            if ip_address is None or ip_address == '':
+
+                self.logger.info('add_port_to_router()', 'Asking address for face: {}'.format(iface))
+                cmd_dhcp_client = 'sudo ip netns exec {} dhclient {}'.format(record['router_ns'], iface)
+                self.call_os_plugin_function('execute_command', {'command':cmd_dhcp_client, 'blocking':True, 'external':True})
+
+                cmd_get_address = 'sudo ip netns exec {} fos_get_address {}'.format(record['router_ns'], iface)
+
+                addr = self.call_os_plugin_function('execute_command', {'command':cmd_get_address, 'blocking':True, 'external':False})
+
+                port_record.update({'ip_address':addr.strip()})
+            else:
+                self.logger.info('add_port_to_router()', 'Assing {} address for face: {}'.format(ip_address, iface))
+                cmd_add_addr = 'sudo ip netns exec {} ip addr add {} dev {}'.format(record['router_ns'], ip_address, iface)
+                self.call_os_plugin_function('execute_command', {'command':cmd_add_addr, 'blocking':True, 'external':True})
+                port_record.update({'ip_address':ip_address})
+
+            self.logger.info('add_port_to_router()', 'Setting iptables rules...')
+
+            record['ports'].append(port_record)
+
+            cmd_iptables_nat = 'sudo ip netns exec {} iptables -t nat -A POSTROUTING -s {} -o {} -j MASQUERADE'.format(record['router_ns'], ip_address, ext_face)
+            cmd_iptables_forward_in = 'sudo ip netns exec {} iptables -A FORWARD -i {} -o {} -j ACCEPT'.format(record['router_ns'], ext_face, iface)
+            cmd_iptables_forward_out = 'sudo ip netns exec {} iptables -A FORWARD -o {} -i {} -j ACCEPT'.format(record['router_ns'], ext_face, iface)
+
+            self.call_os_plugin_function('execute_command', {'command':cmd_iptables_nat, 'blocking':True, 'external':True})
+            self.call_os_plugin_function('execute_command', {'command':cmd_iptables_forward_in, 'blocking':True, 'external':True})
+            self.call_os_plugin_function('execute_command', {'command':cmd_iptables_forward_out, 'blocking':True, 'external':True})
+
+
+
+        else:
+            self.logger.error('add_port_to_router()', 'Router port_type is not recognized: {} or vnet_id is None'.format(port_type))
+            return {'error': 403}
+
+        self.logger.info('add_port_to_router()', 'Router port added')
+        self.routers.update({router_id: record})
+        self.connector.loc.actual.add_node_router(self.node, self.uuid, router_id, record)
+        return {'result': record}
+
+
+    def remove_port_from_router(self, router_id, vnet_id):
+        self.logger.info('remove_port_from_router()', 'Removing port from router {}'.format(router_id))
+        record = self.routers.get(router_id)
+        if record is None:
+            self.logger.error('remove_port_from_router()','Router {} does not exist'.format(router_id))
+            return {'error': 404}
+
+        # Sorting ports to have always the same order
+        ports = sorted(record['ports'], key=lambda k: k['port_type']+k['faces'][0])
+        record.update({'ports': ports})
+
+        ext_face = ports[0]['faces'][0]
+
+        ports = [x for x in record['ports'] if x.get('pair_id') is not None and x.get('pair_id') == vnet_id]
+        if len(ports) == 0:
+            self.logger.error('remove_port_from_router()','Router {} is not connected to {}'.format(router_id, vnet_id))
+            return {'error': 403}
+
+        for p in ports:
+            net_record = self.networks.get(p['pair_id'])
+            net_ns = net_record['properties']['net_ns']
+
+            cmd_remove_face = 'sudo ip netns exec {} ip link del {}'.format(net_ns, p['faces'][1])
+            self.call_os_plugin_function('execute_command', {'command':cmd_remove_face, 'blocking':True, 'external':True})
+
+            cmd_iptables_nat = 'sudo ip netns exec {} iptables -t nat -D POSTROUTING -s {} -o {} -j MASQUERADE'.format(record['router_ns'], p['ip_address'], ext_face)
+            cmd_iptables_forward_in = 'sudo ip netns exec {} iptables -D FORWARD -i {} -o {} -j ACCEPT'.format(record['router_ns'], ext_face, p['faces'][0])
+            cmd_iptables_forward_out = 'sudo ip netns exec {} iptables -D FORWARD -o {} -i {} -j ACCEPT'.format(record['router_ns'], ext_face, p['faces'][0])
+
+            self.call_os_plugin_function('execute_command', {'command':cmd_iptables_nat, 'blocking':True, 'external':True})
+            self.call_os_plugin_function('execute_command', {'command':cmd_iptables_forward_in, 'blocking':True, 'external':True})
+            self.call_os_plugin_function('execute_command', {'command':cmd_iptables_forward_out, 'blocking':True, 'external':True})
+
+            self.logger.info('remove_port_from_router()', 'Removed Internal Face {}'.format(p['faces'][0]))
+
+        ports = list(set(record['ports'])-set(ports))
+        record.update({'ports': ports})
+        self.routers.update({router_id: record})
+        self.connector.loc.actual.add_node_router(self.node, self.uuid, router_id, record)
+        return {'result': record}
+
 
 
     # network_name, net_uuid, ip_range=None, has_dhcp=False, gateway=None,

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -425,7 +425,7 @@ class LinuxBridge(NetworkPlugin):
 
                     addr = self.call_os_plugin_function('execute_command', {'command':cmd_get_address, 'blocking':True, 'external':False})
                     self.logger.info('create_router()', 'Returing: {}'.format(addr))
-                    addr = addr[0]['result']
+
 
                     p.update({'ip_address':addr})
                 else:

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -140,7 +140,10 @@ class LinuxBridge(NetworkPlugin):
             'create_floating_ip': self.create_floating_ip,
             'delete_floating_ip': self.delete_floating_ip,
             'assign_floating_ip': self.assign_floating_ip,
-            'remove_floating_ip': self.remove_floating_ip
+            'remove_floating_ip': self.remove_floating_ip,
+            # utility functions
+            'get_overlay_interface': self.get_overlay_face,
+            'get_vlan_interface': self.get_vlan_face
         }
 
         for k in d:
@@ -179,6 +182,12 @@ class LinuxBridge(NetworkPlugin):
         for k in list(self.bridges.keys()):
             self.delete_virtual_bridge(k)
 
+
+    def get_overlay_face(self):
+        return {'result': self.overlay_interface}
+
+    def get_vlan_face(self):
+        return {'result': self.vlan_face}
 
     def get_address(self, mac_address):
         self.logger.info('get_address()', 'Linux Bridge Plugin - Getting IP address for  {}'.format(mac_address))

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -138,6 +138,8 @@ class LinuxBridge(NetworkPlugin):
             'disconnect_cp': self.disconnect_cp,
             'delete_port': self.delete_port,
             'get_address': self.get_address,
+            'add_router_port': self.add_port_to_router,
+            'remove_router_port': self.remove_port_from_router,
             'create_floating_ip': self.create_floating_ip,
             'delete_floating_ip': self.delete_floating_ip,
             'assign_floating_ip': self.assign_floating_ip,

--- a/fos-plugins/linuxbridge/templates/vnet_create.sh
+++ b/fos-plugins/linuxbridge/templates/vnet_create.sh
@@ -20,8 +20,7 @@
 sudo ip netns add fosns-{{ net_id }}
 sudo ip link add br-{{ net_id }} type bridge
 
-sudo ip link add br-{{ net_id }}-ns type bridge
-sudo ip link set br-{{ net_id }}-ns netns fosns-{{ net_id }}
+sudo ip netns exec  fosns-{{ net_id }} ip link add br-{{ net_id }}-ns type bridge
 
 sudo ip link add l-{{ net_id }}-i type veth peer name l-{{ net_id }}-e
 sudo ip link set l-{{ net_id }}-e netns fosns-{{ net_id }}

--- a/fos-plugins/linuxbridge/templates/vnet_create.sh
+++ b/fos-plugins/linuxbridge/templates/vnet_create.sh
@@ -19,6 +19,18 @@
 
 sudo ip netns add fosns-{{ net_id }}
 sudo ip link add br-{{ net_id }} type bridge
+
+sudo ip link add br-{{ net_id }}-ns type bridge
+sudo ip link set br-{{ net_id }}-ns netns fosns-{{ net_id }}
+
+sudo ip link add l-{{ net_id }}-i type veth peer name l-{{ net_id }}-e
+sudo ip link set l-{{ net_id }}-e netns fosns-{{ net_id }}
+sudo ip link set l-{{ net_id }}-i master br-{{ net_id }}
+sudo ip link set l-{{ net_id }}-i up
+
+sudo ip netns exec fosns-{{ net_id }} ip link set l-{{ net_id }}-e master br-{{ net_id }}-ns
+sudo ip netns exec fosns-{{ net_id }} ip link set l-{{ net_id }}-e up
+
 sudo ip link add name vxl-{{ net_id }} type vxlan id {{ group_id }} group {{ mcast_group_address }} dstport 4789 dev {{ wan }}
 sudo ip link set dev vxl-{{ net_id }} master br-{{ net_id }}
 sudo ip link set up dev br-{{ net_id }}

--- a/fos-plugins/linuxbridge/templates/vnet_create.sh
+++ b/fos-plugins/linuxbridge/templates/vnet_create.sh
@@ -27,6 +27,8 @@ sudo ip link set l-{{ net_id }}-e netns fosns-{{ net_id }}
 sudo ip link set l-{{ net_id }}-i master br-{{ net_id }}
 sudo ip link set l-{{ net_id }}-i up
 
+
+sudo ip netns exec  fosns-{{ net_id }} ip link set br-{{ net_id }}-ns up
 sudo ip netns exec fosns-{{ net_id }} ip link set l-{{ net_id }}-e master br-{{ net_id }}-ns
 sudo ip netns exec fosns-{{ net_id }} ip link set l-{{ net_id }}-e up
 

--- a/fos-plugins/linuxbridge/templates/vnet_destroy.sh
+++ b/fos-plugins/linuxbridge/templates/vnet_destroy.sh
@@ -20,6 +20,7 @@ sudo ip link set br-{{ net_id }} down
 sudo ip link set vxl-{{ net_id }} down
 sudo ip link del br-{{ net_id }}
 sudo ip link del vxl-{{ net_id }}
+sudo ip link del l-{{ net_id }}-i
 sudo ip netns del fosns-{{ net_id }}
 
 

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -679,7 +679,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
              | `INTERNAL ->
                let face_i = Printf.sprintf "r-%s-e%d-i" (List.hd (String.split_on_char '-' rid)) i in
                let face_e = Printf.sprintf "r-%s-e%d-e" (List.hd (String.split_on_char '-' rid)) i in
-               Lwt.return Router.{port_type = `INTERNAL; faces = [face_i; face_e]; ip_address = ""; ext_face = None; pair_id = e.vnet_id}
+               Lwt.return Router.{port_type = `INTERNAL; faces = [face_i; face_e]; ip_address = Apero.Option.get_or_default e.ip_address ""; ext_face = None; pair_id = e.vnet_id}
            ) router.ports
          in
          let vrouter_ns =  Printf.sprintf "r-%s-ns" (List.hd (String.split_on_char '-' rid))  in

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -772,7 +772,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match uuid with
        | Some routerid ->
          MVar.read self >>= fun self ->
-         Yaks_connector.Local.Desired.remove_node_router (Apero.Option.get self.configuration.agent.uuid) net_p routerid self.yaks >>= Lwt.return
+         Yaks_connector.Global.Actual.remove_node_router sys_id Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) routerid self.yaks >>= Lwt.return
        | None -> Lwt.return_unit)
   in
   let cb_la_plugin self (pl:FTypes.plugin option) (is_remove:bool) (uuid:string option) =

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -745,7 +745,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
        | None -> Lwt.return_unit)
 
   in
-  let cb_la_net self (router:Router.record option) (is_remove:bool) (uuid:string option) =
+  let cb_la_router self (router:Router.record option) (is_remove:bool) (uuid:string option) =
     let%lwt net_p = get_network_plugin self in
     match is_remove with
     | false ->
@@ -981,6 +981,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
   let%lwt _ = Yaks_connector.Local.Actual.observe_node_fdu uuid (cb_la_node_fdu state) yaks in
   let%lwt _ = Yaks_connector.Local.Actual.observe_node_network uuid (cb_la_net state) yaks in
   let%lwt _ = Yaks_connector.Local.Actual.observe_node_port uuid (cb_la_cp state) yaks in
+  let%lwt _ = Yaks_connector.Local.Actual.observe_node_router uuid (cb_la_router state) yaks in
   let%lwt _ = Yaks_connector.LocalConstraint.Actual.observe_nodes (cb_lac_nodes state) yaks in
   (* let load_spawner_fun =
      let spawner_path = "_build/default/src/fos/fos-spawner/spawner.exe" in

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -772,7 +772,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match uuid with
        | Some routerid ->
          MVar.read self >>= fun self ->
-         Yaks_connector.Global.Actual.remove_node_router sys_id Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) routerid self.yaks >>= Lwt.return
+         Yaks_connector.Local.Desired.remove_node_router (Apero.Option.get self.configuration.agent.uuid) net_p routerid self.yaks >>= Lwt.return
        | None -> Lwt.return_unit)
   in
   let cb_la_plugin self (pl:FTypes.plugin option) (is_remove:bool) (uuid:string option) =

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -495,7 +495,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     let%lwt net_p = get_network_plugin self in
     let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEL-ROUTER-PORT - # NetManager: %s" net_p) in
     try%lwt
-      let fname = "create_floating_ip" in
+      let fname = "remove_router_port" in
       let rid = Apero.Option.get @@ Apero.Properties.get "router_id" props in
       let vid = Apero.Option.get @@ Apero.Properties.get "vnet_id" props in
       let parameters = [("router_id", rid); ("vnet_id", vid)] in

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -482,8 +482,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       |  None -> let eval_res = FAgentTypes.{result = None ; error=Some 11} in
         Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
-    | _ ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-ADD-ROUTER-PORT - # ERROR WHEN ADDING ROUTER PORT") in
+    | exn ->
+      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-ADD-ROUTER-PORT - # ERROR WHEN ADDING ROUTER PORT: %s" (Printexc.to_string exn) ) in
       let eval_res = FAgentTypes.{result = None ; error=Some 22} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
@@ -519,8 +519,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       |  None -> let eval_res = FAgentTypes.{result = None ; error=Some 11} in
         Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
-    | _ ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-DEL-ROUTER-PORT - # ERROR WHEN REMOVING ROUTER PORT") in
+    | exn ->
+      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-DEL-ROUTER-PORT - # ERROR WHEN REMOVING ROUTER PORT: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error=Some 22} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in

--- a/src/api/python/api/fog05/fimapi.py
+++ b/src/api/python/api/fog05/fimapi.py
@@ -378,6 +378,12 @@ class FIMAPI(object):
             router_id = manifest.get('uuid')
             self.connector.glob.desired.add_node_network_router(
                 self.sysid, self.tenantid, nodeid, router_id, manifest)
+            router_info = self.connector.glob.actual.get_node_network_router(
+                self.sysid, self.tenantid, nodeid, router_id)
+            while router_info is None:
+                    router_info = self.connector.glob.actual.get_node_network_router(
+                self.sysid, self.tenantid, nodeid, router_id)
+            return router_info
 
 
         def remove_router(self, node_id, router_id):

--- a/src/api/python/api/fog05/fimapi.py
+++ b/src/api/python/api/fog05/fimapi.py
@@ -390,6 +390,18 @@ class FIMAPI(object):
             self.connector.glob.desired.remove_node_network_router(
                 self.sysid, self.tenantid, node_id, router_id)
 
+        def add_router_port(self, nodeid, router_id, port_type, vnet_id=None, ip_address=None):
+            if port_type.upper() not in ['EXTERNAL', 'INTERNAL']:
+                raise ValueError("port_type can be only one of : INTERNAL, EXTERNAL")
+
+            port_type = port_type.upper()
+            return self.connector.glob.actual.add_port_to_router(self.sysid, self.tenantid, nodeid, router_id, port_type, vnet_id, ip_address)
+
+        def remove_router_port(self, nodeid, router_id, vnet_id):
+            return self.connector.glob.actual.remove_port_from_router(self.sysid, self.tenantid, nodeid, router_id, vnet_id)
+
+
+
         def create_floating_ip(self, nodeid):
             return self.connector.glob.actual.add_node_floatingip(self.sysid, self.tenantid, nodeid)
 

--- a/src/api/python/api/fog05/fimapi.py
+++ b/src/api/python/api/fog05/fimapi.py
@@ -328,6 +328,7 @@ class FIMAPI(object):
             self.connector.glob.desired.remove_network(
                 self.sysid, self.tenantid, net_uuid)
 
+
         def add_connection_point(self, cp_descriptor):
             cp_descriptor.update({'status': 'add'})
             cp_id = cp_descriptor.get('uuid')
@@ -373,6 +374,15 @@ class FIMAPI(object):
                 return cp_uuid
             raise ValueError('Error connecting: {}'.format(res['error']))
 
+        def add_router(self, nodeid, manifest):
+            router_id = manifest.get('uuid')
+            self.connector.glob.desired.add_node_network_router(
+                self.sysid, self.tenantid, nodeid, router_id, manifest)
+
+
+        def remove_router(self, node_id, router_id):
+            self.connector.glob.desired.remove_node_network_router(
+                self.sysid, self.tenantid, node_id, router_id)
 
         def create_floating_ip(self, nodeid):
             return self.connector.glob.actual.add_node_floatingip(self.sysid, self.tenantid, nodeid)

--- a/src/api/python/api/fog05/yaks_connector.py
+++ b/src/api/python/api/fog05/yaks_connector.py
@@ -887,6 +887,31 @@ class GAD(object):
         else:
             return json.loads(res[0][1].get_value())
 
+    def add_port_to_router(self, sysid, tenantid, nodeid, router_id, port_type, vnet_id=None, ip_address=None):
+        fname = 'add_router_port'
+        params = {'router_id': router_id, "port_type": port_type}
+        if vnet_id is not None and vnet_id is not '':
+            params.update({'vnet_id': vnet_id})
+        if ip_address is not None and ip_address is not '':
+            params.update({'ip_address': ip_address})
+        s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
+        res = self.ws.eval(s)
+        if len(res) == 0:
+            raise ValueError('Empty data on exec_agent_eval')
+        else:
+            return json.loads(res[0][1].get_value())
+
+    def remove_port_from_router(self, sysid, tenantid, nodeid, router_id, vnet_id):
+        fname = 'remove_router_port'
+        params = {'router_id': router_id, "vnet_id": vnet_id}
+        s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
+        res = self.ws.eval(s)
+        if len(res) == 0:
+            raise ValueError('Empty data on exec_agent_eval')
+        else:
+            return json.loads(res[0][1].get_value())
+
+
 
 
 class LAD(object):

--- a/src/api/python/api/fog05/yaks_connector.py
+++ b/src/api/python/api/fog05/yaks_connector.py
@@ -150,6 +150,16 @@ class GAD(object):
             self.prefix,sysid ,'tenants', tenantid,'networks','ports',
             '*', 'info'])
 
+    def get_network_router_info_path(self, sysid, tenantid, routerid):
+        return Constants.create_path(
+            [self.prefix, sysid, 'tenants',
+             tenantid, 'networks', 'routers', routerid, 'info'])
+
+    def get_all_routers_selector(self, sysid, tenantid):
+        return Constants.create_path([
+            self.prefix,sysid ,'tenants', tenantid,'networks','routers',
+            '*', 'info'])
+
     def get_image_info_path(self, sysid, tenantid, imageid):
         return Constants.create_path([
             self.prefix, sysid, 'tenants', tenantid, 'image', imageid, 'info'
@@ -214,8 +224,18 @@ class GAD(object):
             [self.prefix, sysid, 'tenants', tenantid,
             'nodes', nodeid, 'networks', 'ports', portid, 'info'])
 
+    def get_node_network_routers_selector(self, sysid, tenantid, nodeid):
+        return Constants.create_path(
+            [self.prefix, sysid, 'tenants', tenantid,
+            'nodes', nodeid, 'networks', 'routers', '*', 'info'])
 
-        # TODO: this should be in the YAKS api in the creation of a selector
+    def get_node_network_router_info_path(self, sysid, tenantid, nodeid, routerid):
+        return Constants.create_path(
+            [self.prefix, sysid, 'tenants', tenantid,
+            'nodes', nodeid, 'networks', 'routers', routerid, 'info'])
+
+
+    # TODO: this should be in the YAKS api in the creation of a selector
     def dict2args(self, d):
         i = 0
         b = ''
@@ -269,6 +289,9 @@ class GAD(object):
         return path.split('/')[10]
 
     def extract_node_port_id_from_path(self, path):
+        return path.split('/')[9]
+
+    def extract_node_router_id_from_path(self, path):
         return path.split('/')[9]
 
     def extract_node_floatingid_from_path(self, path):
@@ -563,6 +586,30 @@ class GAD(object):
             d.append(json.loads(k[1].get_value()))
         return d
 
+    def get_network_router(self, sysid, tenantid, routerid):
+        s = self.get_network_router_info_path(sysid, tenantid, routerid)
+        kvs = self.ws.get(s)
+        if len(kvs) == 0:
+            return None
+        return json.loads(kvs[0][1].get_value())
+
+    def add_network_router(self, sysid, tenantid, routerid, routerinfo):
+        p = self.get_network_router_info_path(sysid, tenantid, routerid)
+        v = Value(json.dumps(routerinfo), encoding=Encoding.STRING)
+        return self.ws.put(p, v)
+
+    def remove_network_router(self, sysid, tenantid, routerid):
+        p = self.get_network_router_info_path(sysid, tenantid, routerid)
+        return self.ws.remove(p)
+
+    def get_all_network_router(self, sysid, tenantid):
+        p = self.get_all_routers_selector(sysid, tenantid)
+        kvs = self.ws.get(p)
+        d = []
+        for k in kvs:
+            d.append(json.loads(k[1].get_value()))
+        return d
+
     def get_network(self, sysid, tenantid, netid):
         s = self.get_network_info_path(sysid, tenantid, netid)
         kvs = self.ws.get(s)
@@ -739,7 +786,45 @@ class GAD(object):
             v = res[0][1]
             return json.loads(v.get_value())
 
+    #  Routers
 
+    def get_node_network_router(self, sysid, tenantid, nodeid, routerid):
+        s = self.get_node_network_router_info_path(sysid, tenantid, nodeid, routerid)
+        kvs = self.ws.get(s)
+        if len(kvs) == 0:
+            return None
+        return json.loads(kvs[0][1].get_value())
+
+    def add_node_network_router(self, sysid, tenantid, nodeid, routerid, routerinfo):
+        p = self.get_node_network_router_info_path(sysid, tenantid, nodeid, routerid)
+        v = Value(json.dumps(routerinfo), encoding=Encoding.STRING)
+        return self.ws.put(p, v)
+
+    def remove_node_network_router(self, sysid, tenantid, nodeid, routerid):
+        p = self.get_node_network_router_info_path(sysid, tenantid, nodeid, routerid)
+        return self.ws.remove(p)
+
+    def get_all_node_network_routers(self, sysid, tenantid, nodeid):
+        p = self.get_node_network_routers_selector(sysid, tenantid, nodeid)
+        kvs = self.ws.get(p)
+        d = []
+        for k in kvs:
+            d.append(json.loads(k[1].get_value()))
+        return d
+
+    def observe_node_routers(self, sysid, tenantid, nodeid, callback):
+        s = self.get_node_network_routers_selector(sysid, tenantid, nodeid)
+
+        def cb(kvs):
+            if len(kvs) == 0:
+                raise ValueError('Listener received empty datas')
+            else:
+                v = kvs[0][1].get_value()
+                if v is not None:
+                    callback(json.loads(v.value))
+        subid = self.ws.subscribe(s, cb)
+        self.listeners.append(subid)
+        return subid
 
     # Agent Evals
 
@@ -927,11 +1012,6 @@ class LAD(object):
             [self.prefix, nodeid, 'network_managers',
              '*', 'networks', netid, 'info'])
 
-    def get_node_networks_port_selector(self, nodeid, pluginid):
-        return Constants.create_path(
-            [self.prefix, nodeid, 'network_managers',
-             pluginid, 'ports', '*','info'])
-
     def get_node_network_info_path(self, nodeid, pluginid, networkid):
         return Constants.create_path(
             [self.prefix, nodeid, 'network_managers',
@@ -942,6 +1022,22 @@ class LAD(object):
         return Constants.create_path(
             [self.prefix, nodeid, 'network_managers',
              pluginid, 'ports', portid, 'info'])
+
+    def get_node_networks_port_selector(self, nodeid, pluginid):
+        return Constants.create_path(
+            [self.prefix, nodeid, 'network_managers',
+             pluginid, 'ports', '*','info'])
+
+    def get_node_network_router_info_path(self, nodeid, pluginid,
+                                        routerid):
+        return Constants.create_path(
+            [self.prefix, nodeid, 'network_managers',
+             pluginid, 'routers', routerid, 'info'])
+
+    def get_node_network_routers_selector(self, nodeid, pluginid):
+        return Constants.create_path(
+            [self.prefix, nodeid, 'network_managers',
+             pluginid, 'routers', '*','info'])
 
     def get_node_network_floating_ip_info_path(self, nodeid, pluginid, ipid):
         return Constants.create_path([self.prefix, nodeid,
@@ -1021,6 +1117,9 @@ class LAD(object):
 
     def extract_node_instanceid_from_path(self, path):
         return path.split('/')[8]
+
+    def extract_node_routerid_from_path(self, path):
+        return path.split('/')[6]
 
 
     def add_os_eval(self, nodeid, func_name, func):
@@ -1257,6 +1356,8 @@ class LAD(object):
         p = self.get_node_flavor_info_path(nodeid, pluginid, flvid)
         return self.ws.remove(p)
 
+    #  Network
+
     def observe_node_networks(self, nodeid, pluginid, callback):
         s = self.get_node_netwoks_selector(nodeid, pluginid)
 
@@ -1294,6 +1395,16 @@ class LAD(object):
         p = self.get_node_network_info_path(nodeid, pluginid, netid)
         return self.ws.remove(p)
 
+    def get_all_node_networks(self, nodeid, pluginid):
+        s = self.get_node_netwoks_selector(nodeid, pluginid)
+        kvs = self.ws.get(s)
+        d = []
+        for n in kvs:
+            d.append(json.loads(kvs[0][1].get_value()))
+        return d
+
+    # Ports
+
     def add_node_port(self, nodeid, pluginid, portid, portinfo):
         p = self.get_node_network_port_info_path(nodeid, pluginid, portid)
         v = Value(json.dumps(portinfo), encoding=Encoding.STRING)
@@ -1323,6 +1434,55 @@ class LAD(object):
         subid = self.ws.subscribe(s, cb)
         self.listeners.append(subid)
         return subid
+
+    def get_all_node_ports(self, nodeid, pluginid):
+        s = self.get_node_networks_port_selector(nodeid, pluginid)
+        kvs = self.ws.get(s)
+        d = []
+        for n in kvs:
+            d.append(json.loads(kvs[0][1].get_value()))
+        return d
+
+    # Routers
+
+    def add_node_router(self, nodeid, pluginid, routerid, routerinfo):
+        p = self.get_node_network_router_info_path(nodeid, pluginid, routerid)
+        v = Value(json.dumps(routerinfo), encoding=Encoding.STRING)
+        return self.ws.put(p, v)
+
+    def remove_node_router(self, nodeid, pluginid, routerid):
+        p = self.get_node_network_router_info_path(nodeid, pluginid, routerid)
+        return self.ws.remove(p)
+
+    def get_node_router(self, nodeid, pluginid, routerid):
+        s = self.get_node_network_router_info_path(nodeid, pluginid, routerid)
+        res = self.ws.get(s)
+        if len(res) == 0:
+            return None
+        return json.loads(res[0][1].get_value())
+
+    def observe_node_routers(self, nodeid, pluginid, callback):
+        s = self.get_node_network_routers_selector(nodeid, pluginid)
+
+        def cb(kvs):
+            if len(kvs) == 0:
+                raise ValueError('Listener received empty datas')
+            else:
+                v = kvs[0][1].get_value()
+                if v is not None:
+                    callback(json.loads(v.value))
+        subid = self.ws.subscribe(s, cb)
+        self.listeners.append(subid)
+        return subid
+
+    def get_all_node_routers(self, nodeid, pluginid):
+        s = self.get_node_network_routers_selector(nodeid, pluginid)
+        kvs = self.ws.get(s)
+        d = []
+        for n in kvs:
+            d.append(json.loads(kvs[0][1].get_value()))
+        return d
+
     # FLOATING IPs
 
     def add_node_floating_ip(self, nodeid, pluginid, ipid, ipinfo):

--- a/src/core/ocaml/fos-core/yaks_connector.ml
+++ b/src/core/ocaml/fos-core/yaks_connector.ml
@@ -960,7 +960,7 @@ module MakeGAD(P: sig val prefix: string end) = struct
   let observe_node_routers sysid tenantid nodeid callback connector =
     MVar.guarded connector @@ fun connector ->
     let s = get_node_network_routers_selector sysid tenantid nodeid in
-    let%lwt subid = Yaks.Workspace.subscribe ~listener:(sub_cb callback Router.descriptor_of_string extract_routerid_from_path) s connector.ws in
+    let%lwt subid = Yaks.Workspace.subscribe ~listener:(sub_cb callback Router.descriptor_of_string extract_node_routerid_from_path) s connector.ws in
     let ls = List.append connector.listeners [subid] in
     MVar.return subid {connector with listeners = ls}
 

--- a/src/im/ocaml/Makefile
+++ b/src/im/ocaml/Makefile
@@ -11,6 +11,7 @@ atd:
 	atdgen -t fos-im/fos_records_types.atd
 	atdgen -j-std fos-im/fos_records_types.atd
 
+	atdgen -j-std fos-im/router.atd
 	# atdgen -t fos-im/fdu.atd
 	atdgen -j-std fos-im/fdu.atd
 
@@ -29,6 +30,7 @@ clean:
 	rm -rf fos-im/fdu*.ml fos-im/fdu*.mli
 	rm -rf fos-im/nfv*.ml*
 	rm -rf fos-im/mec*.ml*
+	rm -rf fos-im/router*.ml*
 	dune clean
 	rm -rf ./_build
 

--- a/src/im/ocaml/fos-im/fos_im.ml
+++ b/src/im/ocaml/fos-im/fos_im.ml
@@ -28,6 +28,7 @@ module JSON = Abs_json
 
 module Errors = Fos_errors
 module FDU = Fdu
+module Router = Router
 
 module MEC = Mec
 module NFV = Nfv

--- a/src/im/ocaml/fos-im/router.atd
+++ b/src/im/ocaml/fos-im/router.atd
@@ -1,0 +1,46 @@
+(*********************************************************************************
+ * Copyright (c) 2018 ADLINK Technology Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ * Contributors: 1
+ *   Gabriele Baldoni (gabriele (dot) baldoni (at) adlinktech (dot) com ) - vRouter
+ *********************************************************************************)
+
+
+
+type port_kind = [
+  | INTERNAL
+  | EXTERNAL
+]
+
+
+type router_port = {
+  port_type : port_kind;
+  ?vnet_id : string option;
+  ?ip_address : string option;
+}
+
+
+
+type descriptor = {
+  ?uuid : string option;
+  ports : router_port list;
+}
+
+type router_port_record = {
+  port_type : port_kind;
+  face : string;
+  ip_address : string;
+}
+
+type record = {
+  uuid : string;
+  ports : router_port_record list;
+  net_ns : string;
+
+}

--- a/src/im/ocaml/fos-im/router.atd
+++ b/src/im/ocaml/fos-im/router.atd
@@ -18,6 +18,12 @@ type port_kind = [
   | EXTERNAL
 ]
 
+type r_state = [
+  | CREATE
+  | DESTROY
+]
+
+
 
 type router_port = {
   port_type : port_kind;
@@ -34,14 +40,17 @@ type descriptor = {
 
 type router_port_record = {
   port_type : port_kind;
-  face : string;
+  faces : string list;
+  ?ext_face : string option;
   ip_address : string;
+  ?pair_id : string option;
 }
 
 type record = {
   uuid : string;
+  state : r_state;
   ports : router_port_record list;
-  net_ns : string;
+  router_ns : string;
   nodeid :  string
 
 }

--- a/src/im/ocaml/fos-im/router.atd
+++ b/src/im/ocaml/fos-im/router.atd
@@ -42,5 +42,6 @@ type record = {
   uuid : string;
   ports : router_port_record list;
   net_ns : string;
+  nodeid :  string
 
 }


### PR DESCRIPTION
This is the implementation of virtual routers using Linux network namespaces, iptables, Linux bridges and veth interfaces.

it allows the possibility to router between virtual network and external world and between virtual networks.

In order to create a router a new descriptor format was designed:

```
type port_kind = [
  | INTERNAL
  | EXTERNAL
]

type r_state = [
  | CREATE
  | DESTROY
]



type router_port = {
  port_type : port_kind;
  ?vnet_id : string option;
  ?ip_address : string option;
}



type descriptor = {
  ?uuid : string option;
  ports : router_port list;
}

type router_port_record = {
  port_type : port_kind;
  faces : string list;
  ?ext_face : string option;
  ip_address : string;
  ?pair_id : string option;
}

type record = {
  uuid : string;
  state : r_state;
  ports : router_port_record list;
  router_ns : string;
  nodeid :  string

}
```

example of a router descriptor:
```
{
    "uuid": "f2df1b49-1f96-4bce-a35b-e5a8a82adae2",
    "ports": [
        {
            "port_type": "EXTERNAL"
        },
        {
            "port_type": "INTERNAL",
            "vnet_id": "6cc2aa30-1dcf-4c93-a57e-433fd0bd498e",
            "ip_address": "192.168.234.1/24"
        }
    ]
}
```

Also 4 new APIs where added in order to manage the lifecycle of a router:

- FIMAPI.network.add_router(node id, router descriptor)
- FIMAPI.network.remove_router(node id, router id)
- FIMAPI.network.add_router_port(node id , router id, port type, virtual network id, default is None,  ip address in format IP/NETMASK see example, default is None)
- FIMAPI.network.remove_router_port( node id , router id ,  virtual network id )


