### PR TITLE
Implementation of Floating IPs

### DIFF
--- a/fos-plugins/linux/linux_plugin
+++ b/fos-plugins/linux/linux_plugin
@@ -314,7 +314,10 @@ class Linux(OSPlugin):
                 if blocking:
                     p.wait()
                 for line in p.stdout:
-                    r = r + str(line)
+                    if isinstance(line, bytes):
+                        r = r + line.decode()
+                    else:
+                        r = r + str(line)
                     self.logger.debug('execute_command()', str(line))
             res = {'result': r}
         except TypeError as e:

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -1008,7 +1008,7 @@ class LinuxBridge(NetworkPlugin):
         self.logger.error('assign_floating_ip()', 'Moving the virtual interface to router namespace')
         cmd_move_face_to_ns = 'sudo ip link set {} netns {}'.format(rec['vface'], router['router_ns'])
         cmd_reassing_ip = 'sudo ip netns exec {} ip addr add {} dev {}'.format(router['router_ns'], rec['address'], rec['vface'])
-        cmd = 'sudo ip netns exec {} iptables -t nat -A PREROUTING -i {} -j DNAT --to {}'.format(router['router_ns'], rec['vface'], cp_ip)
+        cmd = 'sudo ip netns exec {} iptables -t nat -A PREROUTING -d {} -j DNAT --to {}'.format(router['router_ns'], rec['address'].split('/')[0], cp_ip)
 
         self.call_os_plugin_function('execute_command',{'command':cmd_move_face_to_ns,'blocking':True, 'external':True})
         self.call_os_plugin_function('execute_command',{'command':cmd_reassing_ip,'blocking':True, 'external':True})
@@ -1037,7 +1037,7 @@ class LinuxBridge(NetworkPlugin):
 
         self.logger.info('assign_floating_ip()', 'Moving the virtual interface to default namespace')
 
-        cmd = 'sudo ip netns exec {} iptables -t nat -D PREROUTING -i {} -j DNAT --to {}'.format(router['router_ns'],rec['vface'], cp_ip)
+        cmd = 'sudo ip netns exec {} iptables -t nat -D PREROUTING -d {} -j DNAT --to {}'.format(router['router_ns'], rec['address'].split('/')[0], cp_ip)
         cmd_to_default_ns = 'sudo ip netns exec {} ip link {} set netns 1'.format(router['router_ns'],rec['vface'])
         cmd_assign_ip = 'sudo ip addr add {} dev {}'.format(rec['address'], rec['vface'])
 

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -611,7 +611,7 @@ class LinuxBridge(NetworkPlugin):
 
                 addr = self.call_os_plugin_function('execute_command', {'command':cmd_get_address, 'blocking':True, 'external':False})
 
-                port_record.update({'ip_address':addr.strip()})
+                port_record.update({'ip_address':addr.strip().replace("\\n","")})
             else:
                 self.logger.info('add_port_to_router()', 'Assing {} address for face: {}'.format(ip_address, iface))
                 cmd_add_addr = 'sudo ip netns exec {} ip addr add {} dev {}'.format(record['router_ns'], ip_address, iface)

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -991,7 +991,9 @@ class LinuxBridge(NetworkPlugin):
         self.logger.info('assign_floating_ip()', 'Getting CP external connections')
         fitered_routers = []
         elegible_routers = self.__get_cp_routers(cp_id)
+
         for r in elegible_routers:
+            self.logger.info('assign_floating_ip()', 'Applying filter to router: {}'.format(r))
             for p in r['ports']:
                 if p['port_type'] == 'EXTERNAL' and self.__ip2cidr(p['ip_address']) == self.__ip2cidr(rec['address']):
                     fitered_routers.append(r)
@@ -1000,6 +1002,7 @@ class LinuxBridge(NetworkPlugin):
             self.logger.error('assign_floating_ip()', 'Connection point unreachable from external networks!')
             return {'error': 404}
 
+        self.logger.info('assign_floating_ip()', 'Filtered routers'.format(len(fitered_routers)))
         router = fitered_routers[0]
 
         self.logger.error('assign_floating_ip()', 'Moving the virtual interface to router namespace')

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -1006,11 +1006,14 @@ class LinuxBridge(NetworkPlugin):
         router = fitered_routers[0]
 
         self.logger.error('assign_floating_ip()', 'Moving the virtual interface to router namespace')
+
         cmd_move_face_to_ns = 'sudo ip link set {} netns {}'.format(rec['vface'], router['router_ns'])
+        cmd_dev_up = 'sudo ip netns exec {} ip link set {} up'.format(router['router_ns'], rec['vface'])
         cmd_reassing_ip = 'sudo ip netns exec {} ip addr add {} dev {}'.format(router['router_ns'], rec['address'], rec['vface'])
         cmd = 'sudo ip netns exec {} iptables -t nat -A PREROUTING -d {} -j DNAT --to {}'.format(router['router_ns'], rec['address'].split('/')[0], cp_ip)
 
         self.call_os_plugin_function('execute_command',{'command':cmd_move_face_to_ns,'blocking':True, 'external':True})
+        self.call_os_plugin_function('execute_command',{'command':cmd_dev_up,'blocking':True, 'external':True})
         self.call_os_plugin_function('execute_command',{'command':cmd_reassing_ip,'blocking':True, 'external':True})
         self.call_os_plugin_function('execute_command',{'command':cmd,'blocking':True, 'external':True})
 

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -988,6 +988,7 @@ class LinuxBridge(NetworkPlugin):
             self.logger.error('assign_floating_ip()', 'Connection point {} as not IP'.format(ip_id))
             return {'error': 404}
 
+        self.logger.info('assign_floating_ip()', 'Getting CP external connections')
         fitered_routers = []
         elegible_routers = self.__get_cp_routers(cp_id)
         for r in elegible_routers:
@@ -1031,7 +1032,7 @@ class LinuxBridge(NetworkPlugin):
 
         router = self.routers[rec['router_id']]
 
-        self.logger.error('assign_floating_ip()', 'Moving the virtual interface to default namespace')
+        self.logger.info('assign_floating_ip()', 'Moving the virtual interface to default namespace')
 
         cmd = 'sudo ip netns exec {} iptables -t nat -D PREROUTING -i {} -j DNAT --to {}'.format(router['router_ns'],rec['vface'], cp_ip)
         cmd_to_default_ns = 'sudo ip netns exec {} ip link {} set netns 1'.format(router['router_ns'],rec['vface'])
@@ -1056,8 +1057,8 @@ class LinuxBridge(NetworkPlugin):
         self.logger.info('__get_cp_ip()', 'Get connection point IP for {} Record: {}'.format(cp_id, cp_rec))
         fdus = self.connector.loc.actual.get_node_all_fdus_instances(self.node)
         cp_ip = ''
+        self.logger.info('__get_cp_ip()', 'Scanning FDUs')
         for i in fdus:
-            self.logger.info('__get_cp_ip()', 'Scanning FDUs Record: {}'.format(i))
             intfs = i['interfaces']
             for intf in intfs:
                 if intf.get('cp_id') is not None and intf.get('cp_id') != '':
@@ -1071,29 +1072,32 @@ class LinuxBridge(NetworkPlugin):
 
     def __get_cp_routers(self, cp_id):
         cp_rec = self.connector.loc.actual.get_node_port(self.node, self.uuid, cp_id)
-        self.logger.info('__get_cp_ip()', 'Get connection point IP for {} Record: {}'.format(cp_id, cp_rec))
+        self.logger.info('__get_cp_routers()', 'Get connection point IP for {} Record: {}'.format(cp_id, cp_rec))
         fdus = self.connector.loc.actual.get_node_all_fdus_instances(self.node)
 
         elegible_routers = []
 
         fdu_id = ''
+        self.logger.info('__get_cp_routers()', 'Scanning FDUs')
         for i in fdus:
-            self.logger.info('__get_cp_ip()', 'Scanning FDUs Record: {}'.format(i))
             intfs = i['interfaces']
             for intf in intfs:
                 if intf.get('cp_id') is not None and intf.get('cp_id') != '':
                     if intf.get('cp_id') == cp_rec['uuid']:
                         fdu_id = i['fdu_uuid']
         if fdu_id is '':
-            return ''
+            return elegible_routers
 
         fdud =  self.get_fdu_descriptor(fdu_id)
         netid = ''
+        self.logger.info('__get_cp_routers()', 'Scanning FDU Interfaces')
         for c in fdud['connection_points']:
             if c['uuid'] == cp_rec['uuid']:
                 netid = c['pair_id']
+
+        self.logger.info('__get_cp_routers()', 'CP is connected to {}'.format(netid))
         if netid is '':
-            return ''
+            return elegible_routers
 
 
         for r in self.routers:
@@ -1102,6 +1106,7 @@ class LinuxBridge(NetworkPlugin):
                 if p['port_type'] == 'INTERNAL' and p.get('pair_id','') == netid:
                     elegible_routers.append(router)
 
+        self.logger.info('__get_cp_routers()', 'Got {} elegible routers'.format(len(elegible_routers)))
         return elegible_routers
 
     def get_fdu_descriptor(self, fduid):

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -1092,7 +1092,7 @@ class LinuxBridge(NetworkPlugin):
         netid = ''
         self.logger.info('__get_cp_routers()', 'Scanning FDU Interfaces')
         for c in fdud['connection_points']:
-            if c['uuid'] == cp_rec['uuid']:
+            if c['uuid'] == cp_rec['cp_uuid']:
                 netid = c['pair_id']
 
         self.logger.info('__get_cp_routers()', 'CP is connected to {}'.format(netid))

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -1047,7 +1047,7 @@ class LinuxBridge(NetworkPlugin):
         self.logger.info('assign_floating_ip()', 'Moving the virtual interface to default namespace')
 
         cmd = 'sudo ip netns exec {} iptables -t nat -D PREROUTING -d {} -j DNAT --to {}'.format(router['router_ns'], rec['address'].split('/')[0], cp_ip)
-        cmd_to_default_ns = 'sudo ip netns exec {} ip link {} set netns 1'.format(router['router_ns'],rec['vface'])
+        cmd_to_default_ns = 'sudo ip netns exec {} ip link set {} netns 1'.format(router['router_ns'],rec['vface'])
         cmd_assign_ip = 'sudo ip addr add {} dev {}'.format(rec['address'], rec['vface'])
 
 

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -947,6 +947,8 @@ class LinuxBridge(NetworkPlugin):
         self.call_os_plugin_function('execute_command',{'command':cmd,'blocking':False, 'external':True})
         try:
             addr = netifaces.ifaddresses(vface)[2][0]['addr']
+            mask = netifaces.ifaddresses(face)[2][0]['netmask']
+            addr = self.__ip_mask2cird(addr, mask)
         except:
             self.logger.error('create_floating_ip()','Unable to retrieve address for floating interface')
             addr = ''
@@ -956,7 +958,8 @@ class LinuxBridge(NetworkPlugin):
             'address':addr,
             'face':face,
             'vface':vface,
-            'cp_id':''
+            'cp_id':'',
+            'router_id':''
         }
         self.logger.info('create_floating_ip()',' [ DONE ] New floating IP created {}'.format(float_record))
         self.connector.loc.actual.add_node_floating_ip(self.node, self.uuid, ip_id, float_record)
@@ -974,23 +977,41 @@ class LinuxBridge(NetworkPlugin):
         return {'result': rec}
 
     def assign_floating_ip(self, ip_id, cp_id):
-        # fagent: [ERROR] [FOS-AGENT] - EV-ASSOC-FLOATING-IP - EXCEPTION: (Failure
-        # "[YAS]:
-        # EVAL on /alfos/a2d358aa-af2b-42cb-8d23-a89e88b97e5c/network_managers/d42b4163-af35-423a-acb4-a228290cf0be/exec/assign_floating_ip?(ip_id=c02eea4f-6f35-4a87-b8bb-b9ba617e8214;cp_id=a47a8819-72e5-4b4e-86fd-fc30c9fda68b):
-        # ErrNo 400")
         self.logger.info('assign_floating_ip()', 'Assigning floating IP {} to {}'.format(ip_id, cp_id))
         rec = self.connector.loc.actual.get_node_floating_ip(self.node, self.uuid, ip_id)
         if rec is None:
             self.logger.error('assign_floating_ip()', 'Not found IP: {}'.format(ip_id))
-            return {'error': 11}
+            return {'error': 404}
 
         cp_ip = self.__get_cp_ip(cp_id)
         if cp_ip == '':
             self.logger.error('assign_floating_ip()', 'Connection point {} as not IP'.format(ip_id))
-            return {'error': 11}
-        cmd = 'sudo iptables -t nat -A PREROUTING -d {} -j DNAT --to {}'.format(rec['vface'], cp_ip)
+            return {'error': 404}
+
+        fitered_routers = []
+        elegible_routers = self.__get_cp_routers(cp_id)
+        for r in elegible_routers:
+            for p in r['ports']:
+                if p['port_type'] == 'EXTERNAL' and self.__ip2cidr(p['ip_address']) == self.__ip2cidr(rec['address']):
+                    fitered_routers.append(r)
+
+        if len(fitered_routers) == 0:
+            self.logger.error('assign_floating_ip()', 'Connection point unreachable from external networks!')
+            return {'error': 404}
+
+        router = fitered_routers[0]
+
+        self.logger.error('assign_floating_ip()', 'Moving the virtual interface to router namespace')
+        cmd_move_face_to_ns = 'sudo ip link set {} netns {}'.format(rec['vface'], router['router_ns'])
+        cmd_reassing_ip = 'sudo ip netns exec {} ip addr add {} dev {}'.format(router['router_ns'], rec['address'], rec['vface'])
+        cmd = 'sudo ip netns exec {} iptables -t nat -A PREROUTING -i {} -j DNAT --to {}'.format(router['router_ns'], rec['vface'], cp_ip)
+
+        self.call_os_plugin_function('execute_command',{'command':cmd_move_face_to_ns,'blocking':True, 'external':True})
+        self.call_os_plugin_function('execute_command',{'command':cmd_reassing_ip,'blocking':True, 'external':True})
         self.call_os_plugin_function('execute_command',{'command':cmd,'blocking':True, 'external':True})
+
         rec.update({'cp_id':cp_id})
+        rec.update({'router_id':router['uuid']})
         self.connector.loc.actual.add_node_floating_ip(self.node, self.uuid, ip_id, rec)
         self.logger.info('assign_floating_ip()', '[DONE] assigned floating IP {} to {}'.format(ip_id, cp_id))
         return {'result': rec}
@@ -1002,14 +1023,27 @@ class LinuxBridge(NetworkPlugin):
         rec = self.connector.loc.actual.get_node_floating_ip(self.node, self.uuid, ip_id)
         if rec is None:
             self.logger.error('remove_floating_ip()', 'Not found IP: {}'.format(ip_id))
-            return {'error': 11}
+            return {'error': 404}
         cp_ip = self.__get_cp_ip(cp_id)
         if cp_ip == '':
             self.logger.error('remove_floating_ip()', 'Connection point {} has no IP'.format(ip_id))
-            return {'error': 11}
-        cmd = 'sudo iptables -t nat -D PREROUTING -d {} -j DNAT --to {}'.format(rec['vface'], cp_ip)
+            return {'error': 404}
+
+        router = self.routers[rec['router_id']]
+
+        self.logger.error('assign_floating_ip()', 'Moving the virtual interface to default namespace')
+
+        cmd = 'sudo ip netns exec {} iptables -t nat -D PREROUTING -i {} -j DNAT --to {}'.format(router['router_ns'],rec['vface'], cp_ip)
+        cmd_to_default_ns = 'sudo ip netns exec {} ip link {} set netns 1'.format(router['router_ns'],rec['vface'])
+        cmd_assign_ip = 'sudo ip addr add {} dev {}'.format(rec['address'], rec['vface'])
+
+
         self.call_os_plugin_function('execute_command',{'command':cmd,'blocking':True, 'external':True})
+        self.call_os_plugin_function('execute_command',{'command':cmd_to_default_ns,'blocking':True, 'external':True})
+        self.call_os_plugin_function('execute_command',{'command':cmd_assign_ip,'blocking':True, 'external':True})
+
         rec.update({'cp_id':''})
+        rec.update({'router_id':''})
         self.connector.loc.actual.add_node_floating_ip(self.node, self.uuid, ip_id, rec)
         self.logger.info('remove_floating_ip()', '[DONE] removed floating IP {} from {}'.format(ip_id, cp_id))
         return {'result': rec}
@@ -1035,6 +1069,46 @@ class LinuxBridge(NetworkPlugin):
         self.logger.info('__get_cp_ip()', 'IP for {} -> {}'.format(cp_id, cp_ip))
         return cp_ip
 
+    def __get_cp_routers(self, cp_id):
+        cp_rec = self.connector.loc.actual.get_node_port(self.node, self.uuid, cp_id)
+        self.logger.info('__get_cp_ip()', 'Get connection point IP for {} Record: {}'.format(cp_id, cp_rec))
+        fdus = self.connector.loc.actual.get_node_all_fdus_instances(self.node)
+
+        elegible_routers = []
+
+        fdu_id = ''
+        for i in fdus:
+            self.logger.info('__get_cp_ip()', 'Scanning FDUs Record: {}'.format(i))
+            intfs = i['interfaces']
+            for intf in intfs:
+                if intf.get('cp_id') is not None and intf.get('cp_id') != '':
+                    if intf.get('cp_id') == cp_rec['uuid']:
+                        fdu_id = i['fdu_uuid']
+        if fdu_id is '':
+            return ''
+
+        fdud =  self.get_fdu_descriptor(fdu_id)
+        netid = ''
+        for c in fdud['connection_points']:
+            if c['uuid'] == cp_rec['uuid']:
+                netid = c['pair_id']
+        if netid is '':
+            return ''
+
+
+        for r in self.routers:
+            router = self.routers[r]
+            for p in router['ports']:
+                if p['port_type'] == 'INTERNAL' and p.get('pair_id','') == netid:
+                    elegible_routers.append(router)
+
+        return elegible_routers
+
+    def get_fdu_descriptor(self, fduid):
+        parameters = {'fdu_uuid': fduid}
+        fname = 'get_fdu_info'
+        return self.call_agent_function(fname, parameters)
+
     def __cird2block(self, cird):
         '''
             Convert cird subnet to first address (for router), first dhcp, last dhcp, netmask
@@ -1054,6 +1128,16 @@ class LinuxBridge(NetworkPlugin):
         return socket.inet_ntoa(struct.pack('>I', start + 1)), socket.inet_ntoa(
             struct.pack('>I', start + 2)), socket.inet_ntoa(struct.pack('>I', end - 1)), netmask
 
+
+    def __ip2cidr(self, ip):
+        (ip, cidr) = ip.split('/')
+        cidr = int(cidr)
+        host_bits = 32 - cidr
+        i = struct.unpack('>I', socket.inet_aton(ip))[0]
+        start = (i >> host_bits) << host_bits
+        return socket.inet_ntoa(struct.pack('>I', start))+'/'+str(cidr)
+
+
     def __get_net_size(self, netmask):
         binary_str = ''
         for octet in netmask:
@@ -1071,6 +1155,20 @@ class LinuxBridge(NetworkPlugin):
         ip = ip.split('.')
         mask = mask.split('.')
         net_start = [str(int(ip[x]) & int(mask[x])) for x in range(0, 4)]
+        return '.'.join(net_start) + '/' + self.__get_net_size(mask)
+
+
+    def __ip_mask2cird(self,ip, mask):
+
+        try:
+            socket.inet_aton(ip)
+            socket.inet_aton(mask)
+        except:
+            return "0.0.0.0/0"
+
+        ip = ip.split('.')
+        mask = mask.split('.')
+        net_start = [str(int(ip[x])) for x in range(0, 4)]
         return '.'.join(net_start) + '/' + self.__get_net_size(mask)
 
 

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -85,6 +85,7 @@ class LinuxBridge(NetworkPlugin):
         self.ports = {}
         self.bridges = {}
         self.routers = {}
+        self.floating_ips = {}
 
         signal.signal(signal.SIGINT, self.__catch_signal)
         signal.signal(signal.SIGTERM, self.__catch_signal)
@@ -188,6 +189,8 @@ class LinuxBridge(NetworkPlugin):
             self.delete_virtual_bridge(k)
         for k in list(self.routers.keys()):
             self.delete_router(k)
+        for k in list(self.floating_ips.keys()):
+            self.delete_floating_ip(k)
 
 
     def get_overlay_face(self):
@@ -963,6 +966,7 @@ class LinuxBridge(NetworkPlugin):
         }
         self.logger.info('create_floating_ip()',' [ DONE ] New floating IP created {}'.format(float_record))
         self.connector.loc.actual.add_node_floating_ip(self.node, self.uuid, ip_id, float_record)
+        self.floating_ips.update({ip_id: float_record})
         return {'result':float_record}
 
     def delete_floating_ip(self, ip_id):
@@ -974,6 +978,7 @@ class LinuxBridge(NetworkPlugin):
         rec = self.connector.loc.actual.get_node_floating_ip(self.node, self.uuid, ip_id)
         self.connector.loc.actual.remove_node_floating_ip(self.node, self.uuid, ip_id)
         self.logger.info('delete_floating_ip()', '[DONE] Deletted IP {}'.format(ip_id))
+        self.floating_ips.pop(ip_id)
         return {'result': rec}
 
     def assign_floating_ip(self, ip_id, cp_id):
@@ -1002,7 +1007,7 @@ class LinuxBridge(NetworkPlugin):
             self.logger.error('assign_floating_ip()', 'Connection point unreachable from external networks!')
             return {'error': 404}
 
-        self.logger.info('assign_floating_ip()', 'Filtered routers'.format(len(fitered_routers)))
+        self.logger.info('assign_floating_ip()', 'Filtered routers: {}'.format(len(fitered_routers)))
         router = fitered_routers[0]
 
         self.logger.error('assign_floating_ip()', 'Moving the virtual interface to router namespace')
@@ -1021,6 +1026,7 @@ class LinuxBridge(NetworkPlugin):
         rec.update({'router_id':router['uuid']})
         self.connector.loc.actual.add_node_floating_ip(self.node, self.uuid, ip_id, rec)
         self.logger.info('assign_floating_ip()', '[DONE] assigned floating IP {} to {}'.format(ip_id, cp_id))
+        self.floating_ips.update({ip_id: rec})
         return {'result': rec}
 
 
@@ -1053,6 +1059,7 @@ class LinuxBridge(NetworkPlugin):
         rec.update({'router_id':''})
         self.connector.loc.actual.add_node_floating_ip(self.node, self.uuid, ip_id, rec)
         self.logger.info('remove_floating_ip()', '[DONE] removed floating IP {} from {}'.format(ip_id, cp_id))
+        self.floating_ips.update({ip_id: rec})
         return {'result': rec}
 
     # ============ #


### PR DESCRIPTION
This implements the possibility to assing a Floating IP, and IP address in the same network of the physical one of the node, to a running FDU. Solves #111 

To enable this 4 new APIs are added:
- FIMAPI.network.create_floating_ip( nodeid )
- FIMAPI.network.assign_floating_ip( nodeid, floating ip id, connection point id)
- FIMAPI.network.retain_floating_ip( nodeid, floating ip id, connection point id)
- FIMAPI.network.delete_floating_ip( nodeid, floating ip id)


Example of usage:
```
>>> from fog05 import FIMAPI; a=FIMAPI()
>>> fip = a.network.create_floating_ip('4a560914-1c3e-4966-9fa8-7f0acc903253')
>>> fip
{'result': {'uuid': 'fff134fe-5d6c-402f-983d-1800a610405a', 'ip_version': 'IPV4', 'address': '192.168.86.208/24'}}
>>> a.fdu.instance_info('a5ae5fbb-fb4b-48a8-ac93-2123d5f7b10e')
{'fdu_uuid': '1e57bb0e-cb41-4b23-bca3-1fa761a83c02', 'node': '4a560914-1c3e-4966-9fa8-7f0acc903253', 'uuid': 'a5ae5fbb-fb4b-48a8-ac93-2123d5f7b10e', 'status': 'RUN', 'interfaces': [{'vintf_name': 'eth0', 'status': 'CREATE', 'if_type': 'VIRTIO', 'mac_address': 'be:ef:be:ef:00:01', 'cp_id': 'cc4b97d2-baf7-4006-a928-7710e83c8a7c'}], 'connection_points': [{'uuid': 'cc4b97d2-baf7-4006-a928-7710e83c8a7c', 'status': 'CREATE', 'cp_uuid': 'a47a8819-72e5-4b4e-86fd-fc30c9fda68b'}], 'hypervisor_info': {'network': {'eth0': {'hwaddr': 'be:ef:be:ef:00:01', 'addresses': [{'address': '192.168.234.10'}]}}, 'cpu': {'usage': 2709500253}, 'memory': {'usage': 11534336, 'usage_peak': 20119552, 'swap_usage': 0, 'swap_usage_peak': 0}}, 'accelerators': {'fpga': [], 'gpu': []}, 'io_ports': []}
a.network.assign_floating_ip('4a560914-1c3e-4966-9fa8-7f0acc903253','fff134fe-5d6c-402f-983d-1800a610405a','cc4b97d2-baf7-4006-a928-7710e83c8a7c')
{'result': {'uuid': 'fff134fe-5d6c-402f-983d-1800a610405a', 'ip_version': 'IPV4', 'address': '192.168.86.208/24'}}
>>> a.network.retain_floating_ip('4a560914-1c3e-4966-9fa8-7f0acc903253','fff134fe-5d6c-402f-983d-1800a610405a','cc4b97d2-baf7-4006-a928-7710e83c8a7c')
```
