### PR TITLE
Support for Entity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ all:
 	make -C src/core/ocaml install
 	make -C src/api/ocaml/fimapi install
 	make -C src/api/ocaml/faemapi install
+	make -C src/api/ocaml/feoapi install
 	make -C src/agent/;
 
 install:

--- a/examples/im/lxd_entity.json
+++ b/examples/im/lxd_entity.json
@@ -20,6 +20,5 @@
             "cps": []
         }
     ],
-    "connection_points": [],
-    "depends_on": []
+    "connection_points": []
 }

--- a/examples/im/lxd_entity.json
+++ b/examples/im/lxd_entity.json
@@ -1,0 +1,25 @@
+{
+    "id": "one-fdu-atomic-entity",
+    "name": "test_atomic_entity",
+    "description": "this is a simple atomic entity composed by two LXD containers",
+    "atomic_entities": [
+        "one-fdu-atomic-entity"
+    ],
+    "internal_virtual_links": [
+        {
+            "id": "datanet-vl",
+            "name": "datanet",
+            "ip_configuration": {
+                "ip_version": "IPV4",
+                "subnet": "192.168.123.0/24",
+                "gateway": "192.168.123.1",
+                "dhcp_enable": true,
+                "dhcp_range": "192.168.123.2,192.168.123.100",
+                "dns": "8.8.8.8,8.8.4.4"
+            },
+            "cps": []
+        }
+    ],
+    "connection_points": [],
+    "depends_on": []
+}

--- a/fos-plugins/KVM/KVM_plugin
+++ b/fos-plugins/KVM/KVM_plugin
@@ -294,7 +294,7 @@ class KVM(RuntimePluginFDU):
                     intf_name = intf.get('name')
                     mac = intf.get('mac_address', self.__generate_random_mac())
                     intf.update({'mac_address': mac})
-                    if intf.get('if_type').upper() in ['PHYSICAL','BRIDGED']:
+                    if intf.get('virtual_interface').get('intf_type').upper() in ['PHYSICAL','BRIDGED']:
                         real_intf_name = intf.get('phy_face')
                         if self.os.get_intf_type(real_intf_name) in ['ethernet']:
                             net_cfg.append({'name':intf_name, 'mac':mac, 'dev':real_intf_name,'type':'direct'})
@@ -424,7 +424,7 @@ class KVM(RuntimePluginFDU):
 
             for i, intf in enumerate(fdu.get_interfaces()):
                 intf_name = intf.get('name')
-                if intf.get('if_type').upper() not in ['PHYSICAL','BRIDGED']:
+                if intf.get('virtual_interface').get('intf_type').upper() not in ['PHYSICAL','BRIDGED']:
                     intf_id = 'kvm-{}-{}'.format(fdu.get_short_id(), i)
                     # self.nm.delete_virtual_interface(intf_id)
                 else:
@@ -679,7 +679,7 @@ class KVM(RuntimePluginFDU):
                     intf_name = intf.get('name')
                     mac = intf.get('mac_address', self.__generate_random_mac())
                     intf.update({'mac_address': mac})
-                    if intf.get('if_type').upper() in ['PHYSICAL','BRIDGED']:
+                    if intf.get('virtual_interface').get('intf_type').upper() in ['PHYSICAL','BRIDGED']:
                         real_intf_name = intf.get('phy_face')
                         if self.os.get_intf_type(real_intf_name) in ['ethernet']:
                             net_cfg.append({'name':intf_name, 'mac':mac, 'dev':real_intf_name,'type':'direct'})

--- a/fos-plugins/LXD/LXD_plugin
+++ b/fos-plugins/LXD/LXD_plugin
@@ -845,30 +845,39 @@ class LXD(RuntimePluginFDU):
 
 
     def connect_interface_to_cp(self, cpid, instanceid, iface):
-        fdu = self.current_fdus.get(instanceid, None)
-        if fdu is None:
-            self.logger.error('run_fdu()', 'LXD Plugin - FDU not exists')
-            return {'error':404, 'error_msg': 'FDU {} not in runtime {}'.format(instanceid, self.uuid) }
-        elif fdu.get_status() not in [State.CONFIGURED. State.RUNNING, State.PAUSED]:
-            self.logger.error('run_fdu()', 'LXD Plugin - FDU state is wrong, or transition not allowed')
-            return {'error':404, 'error_msg': 'FDU {} is not in correct state'.format(instanceid)}
-        else:
-            fdu_uuid = fdu.get_fdu_id()
-            face = ''
+        self.logger.error('connect_interface_to_cp()', 'CP {} <->  {}:{}'.format(cpid, instanceid, iface))
+        try:
+            fdu = self.current_fdus.get(instanceid, None)
+            if fdu is None:
+                self.logger.error('run_fdu()', 'LXD Plugin - FDU not exists')
+                return {'error':404, 'error_msg': 'FDU {} not in runtime {}'.format(instanceid, self.uuid) }
+            elif fdu.get_status() not in [State.CONFIGURED. State.RUNNING, State.PAUSED]:
+                self.logger.error('run_fdu()', 'LXD Plugin - FDU state is wrong, or transition not allowed')
+                return {'error':404, 'error_msg': 'FDU {} is not in correct state'.format(instanceid)}
+            else:
+                fdu_uuid = fdu.get_fdu_id()
+                face = ''
 
-            i = 0
-            for intf in fdu.get_interfaces():
-                intf_name = intf.get('vintf_name')
-                if intf.get('virtual_interface').get('intf_type').upper() not in ['PHYSICAL','BRIDGED']:
-                    intf_id = 'lxd-{}-{}'.format(fdu.get_short_id(), i)
-                    if intf.get('name') == iface:
-                        face = intf_id
-            if face == '':
-                return {'error':404, 'error_msg': 'Unable to find interface {}'.format(iface)}
-            r = self.nm.connect_interface_to_connection_point(face,cpid)
-            if r.get('result') is not None:
-                return {'result':cpid}
-            return {'error':503, 'error_msg': 'Unable to attach interface {} to cp'.format(iface)}
+                i = 0
+                for intf in fdu.get_interfaces():
+                    intf_name = intf.get('vintf_name')
+                    if intf.get('virtual_interface').get('intf_type').upper() not in ['PHYSICAL','BRIDGED']:
+                        intf_id = 'lxd-{}-{}'.format(fdu.get_short_id(), i)
+                        if intf.get('name') == iface:
+                            face = intf_id
+                if face == '':
+                    return {'error':404, 'error_msg': 'Unable to find interface {}'.format(iface)}
+                r = self.nm.connect_interface_to_connection_point(face,cpid)
+                if r.get('result') is not None:
+                    return {'result':cpid}
+                return {'error':503, 'error_msg': 'Unable to attach interface {} to cp'.format(iface)}
+        except Exception as e:
+            import traceback
+            self.logger.error('create_port_from_descriptor()', '[ERROR] {}'.format(traceback.format_exc()))
+            traceback.format_exc()
+            self.logger.error('create_port_from_descriptor()', '[ERROR] got error {}'.format(e))
+            return {'error':503, 'error_msg':'{}'.format(e)}
+
 
     def disconnect_interface_from_cp(self, iface, instanceid):
         fdu = self.current_fdus.get(instanceid, None)

--- a/fos-plugins/LXD/LXD_plugin
+++ b/fos-plugins/LXD/LXD_plugin
@@ -65,6 +65,20 @@ class LXD(RuntimePluginFDU):
         self.images = {}
         self.flavors = {}
         self.mon_th = {}
+
+
+        d = {
+            'connect_interface_to_cp': self.connect_interface_to_cp,
+            'disconnect_interface_from_cp': self.disconnect_interface_from_cp,
+        }
+
+        for k in d:
+            f = d.get(k)
+            self.logger.info(
+                '__init__()', 'LXD Plugin - Registering {}'.format(k))
+            self.connector.loc.actual.add_plugin_eval(self.node, self.uuid, k, f)
+
+
         signal.signal(signal.SIGINT, self.__catch_signal)
         signal.signal(signal.SIGTERM, self.__catch_signal)
 
@@ -827,6 +841,60 @@ class LXD(RuntimePluginFDU):
 
     def after_migrate_entity_actions(self, fdu_uuid, dst=False):
         pass
+
+
+
+    def connect_interface_to_cp(self, cpid, instanceid, iface):
+        fdu = self.current_fdus.get(instanceid, None)
+        if fdu is None:
+            self.logger.error('run_fdu()', 'LXD Plugin - FDU not exists')
+            return {'error':404, 'error_msg': 'FDU {} not in runtime {}'.format(instanceid, self.uuid) }
+        elif fdu.get_status() not in [State.CONFIGURED. State.RUNNING, State.PAUSED]:
+            self.logger.error('run_fdu()', 'LXD Plugin - FDU state is wrong, or transition not allowed')
+            return {'error':404, 'error_msg': 'FDU {} is not in correct state'.format(instanceid)}
+        else:
+            fdu_uuid = fdu.get_fdu_id()
+            face = ''
+
+            i = 0
+            for intf in fdu.get_interfaces():
+                intf_name = intf.get('vintf_name')
+                if intf.get('virtual_interface').get('intf_type').upper() not in ['PHYSICAL','BRIDGED']:
+                    intf_id = 'lxd-{}-{}'.format(fdu.get_short_id(), i)
+                    if intf.get('name') == iface:
+                        face = intf_id
+            if face == '':
+                return {'error':404, 'error_msg': 'Unable to find interface {}'.format(iface)}
+            r = self.nm.connect_interface_to_connection_point(face,cpid)
+            if r.get('result') is not None:
+                return {'result':cpid}
+            return {'error':503, 'error_msg': 'Unable to attach interface {} to cp'.format(iface)}
+
+    def disconnect_interface_from_cp(self, iface, instanceid):
+        fdu = self.current_fdus.get(instanceid, None)
+        if fdu is None:
+            self.logger.error('run_fdu()', 'LXD Plugin - FDU not exists')
+            return {'error':404, 'error_msg': 'FDU {} not in runtime {}'.format(instanceid, self.uuid) }
+        elif fdu.get_status() not in [State.CONFIGURED. State.RUNNING, State.PAUSED]:
+            self.logger.error('run_fdu()', 'LXD Plugin - FDU state is wrong, or transition not allowed')
+            return {'error':404, 'error_msg': 'FDU {} is not in correct state'.format(instanceid)}
+        else:
+            fdu_uuid = fdu.get_fdu_id()
+            face = ''
+
+            i = 0
+            for intf in fdu.get_interfaces():
+                intf_name = intf.get('vintf_name')
+                if intf.get('virtual_interface').get('intf_type').upper() not in ['PHYSICAL','BRIDGED']:
+                    intf_id = 'lxd-{}-{}'.format(fdu.get_short_id(), i)
+                    if intf.get('name') == iface:
+                        face = intf_id
+            if face == '':
+                return {'error':404, 'error_msg': 'Unable to find interface {}'.format(iface)}
+            r = self.nm.disconnect_interface(face)
+            if r.get('result') is not None:
+                return {'result':iface}
+            return {'error':503, 'error_msg': 'Unable to disconnect interface {} to cp'.format(iface)}
 
     def __monitor_instance(self, fdu_uuid, instance_id, instance_name):
         self.logger.info('__monitor_instance()','[ INFO ] LXD Plugin - Staring monitoring of Container uuid {}'.format(instance_id))

--- a/fos-plugins/LXD/LXD_plugin
+++ b/fos-plugins/LXD/LXD_plugin
@@ -849,10 +849,10 @@ class LXD(RuntimePluginFDU):
         try:
             fdu = self.current_fdus.get(instanceid, None)
             if fdu is None:
-                self.logger.error('run_fdu()', 'LXD Plugin - FDU not exists')
+                self.logger.error('connect_interface_to_cp()', 'LXD Plugin - FDU not exists')
                 return {'error':404, 'error_msg': 'FDU {} not in runtime {}'.format(instanceid, self.uuid) }
-            elif fdu.get_status() not in [State.CONFIGURED. State.RUNNING, State.PAUSED]:
-                self.logger.error('run_fdu()', 'LXD Plugin - FDU state is wrong, or transition not allowed')
+            elif fdu.get_status() not in [State.CONFIGURED, State.RUNNING, State.PAUSED]:
+                self.logger.error('connect_interface_to_cp()', 'LXD Plugin - FDU state is wrong, or transition not allowed')
                 return {'error':404, 'error_msg': 'FDU {} is not in correct state'.format(instanceid)}
             else:
                 fdu_uuid = fdu.get_fdu_id()
@@ -868,24 +868,24 @@ class LXD(RuntimePluginFDU):
                 if face == '':
                     return {'error':404, 'error_msg': 'Unable to find interface {}'.format(iface)}
                 r = self.nm.connect_interface_to_connection_point(face,cpid)
-                if r.get('result') is not None:
-                    return {'result':cpid}
-                return {'error':503, 'error_msg': 'Unable to attach interface {} to cp'.format(iface)}
+                self.logger.error('connect_interface_to_cp()', 'NM Returned {}'.format(r))
+                return {'result':cpid}
+
         except Exception as e:
             import traceback
-            self.logger.error('create_port_from_descriptor()', '[ERROR] {}'.format(traceback.format_exc()))
+            self.logger.error('connect_interface_to_cp()', '[ERROR] {}'.format(traceback.format_exc()))
             traceback.format_exc()
-            self.logger.error('create_port_from_descriptor()', '[ERROR] got error {}'.format(e))
+            self.logger.error('connect_interface_to_cp()', '[ERROR] got error {}'.format(e))
             return {'error':503, 'error_msg':'{}'.format(e)}
 
 
     def disconnect_interface_from_cp(self, iface, instanceid):
         fdu = self.current_fdus.get(instanceid, None)
         if fdu is None:
-            self.logger.error('run_fdu()', 'LXD Plugin - FDU not exists')
+            self.logger.error('disconnect_interface_from_cp()', 'LXD Plugin - FDU not exists')
             return {'error':404, 'error_msg': 'FDU {} not in runtime {}'.format(instanceid, self.uuid) }
-        elif fdu.get_status() not in [State.CONFIGURED. State.RUNNING, State.PAUSED]:
-            self.logger.error('run_fdu()', 'LXD Plugin - FDU state is wrong, or transition not allowed')
+        elif fdu.get_status() not in [State.CONFIGURED, State.RUNNING, State.PAUSED]:
+            self.logger.error('disconnect_interface_from_cp()', 'LXD Plugin - FDU state is wrong, or transition not allowed')
             return {'error':404, 'error_msg': 'FDU {} is not in correct state'.format(instanceid)}
         else:
             fdu_uuid = fdu.get_fdu_id()

--- a/fos-plugins/LXD/LXD_plugin
+++ b/fos-plugins/LXD/LXD_plugin
@@ -462,7 +462,7 @@ class LXD(RuntimePluginFDU):
             i = 0
             for intf in fdu.get_interfaces():
                 intf_name = intf.get('vintf_name')
-                if intf.get('if_type').upper() not in ['PHYSICAL','BRIDGED']:
+                if intf.get('virtual_interface').get('intf_type').upper() not in ['PHYSICAL','BRIDGED']:
                     intf_id = 'lxd-{}-{}'.format(fdu.get_short_id(), i)
                     self.logger.info('clean_fdu()','Asking for the deletion of virtual interface {}'.format(intf_id))
                     self.nm.delete_virtual_interface(intf_id)
@@ -778,7 +778,7 @@ class LXD(RuntimePluginFDU):
                 intf_name = intf.get('vintf_name')
                 mac = intf.get('mac_address', self.__generate_random_mac())
                 intf.update({'mac_address': mac})
-                if intf.get('if_type').upper() in ['PHYSICAL','BRIDGED']:
+                if intf.get('virtual_interface').get('intf_type').upper() in ['PHYSICAL','BRIDGED']:
                     real_intf_name = intf.get('phy_face')
                     if self.os.get_intf_type(real_intf_name) in ['ethernet']:
                         self.os.set_interface_unaviable(real_intf_name)
@@ -924,9 +924,10 @@ class LXD(RuntimePluginFDU):
             self.logger.info('__generate_custom_profile_devices_configuration()','Interface Info {}'.format(intf))
             mac = intf.get('mac_address', self.__generate_random_mac())
             intf.update({'mac_address': mac})
-
-            if intf.get('if_type').upper() in ['PHYSICAL','BRIDGED']:
-                real_intf_name = intf.get('phy_face')
+            if intf.get('virtual_interface').get('intf_type').upper() in ['PHYSICAL','BRIDGED']:
+                real_intf_name = intf.get('phy_face', None)
+                if real_intf_name is None:
+                    raise ValueError("phy_face cannot be none")
                 if self.os.get_intf_type(real_intf_name) in ['ethernet']:
                     nw_v = json.loads(str(template_value_macvlan_mac % (intf_name, real_intf_name, mac)))
                     self.os.set_interface_unaviable(real_intf_name)

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -1076,8 +1076,10 @@ class LinuxBridge(NetworkPlugin):
         self.os.remove_file(stop_file)
         self.os.remove_file(port_info.get('start'))
         self.ports.pop(cp_id)
+        rec = self.connector.loc.actual.get_node_port(self.node, self.uuid, cp_id)
+        rec.update({'STATUS':'DESTROY'})
         self.connector.loc.actual.remove_node_port(self.node, self.uuid, cp_id)
-        return {'result':port_info}
+        return {'result':rec}
 
         # ================================= #
 

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -1032,9 +1032,9 @@ class LinuxBridge(NetworkPlugin):
             'stop':cmd_stop
         }
         self.ports.update({cp_uuid: cp_info})
-        if descriptor.get("vld_ref") is not None:
-            pair_id = descriptor.get("vld_ref")
-            self.connect_cp_to_vnetwork(cp_id, pair_id)
+        # if descriptor.get("vld_ref") is not None:
+        #     pair_id = descriptor.get("vld_ref")
+        #     self.connect_cp_to_vnetwork(cp_id, pair_id)
         properties = {
             'int_name': int_name,
             'ext_name':ext_name,

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -336,9 +336,9 @@ class LinuxBridge(NetworkPlugin):
             'stop':cmd_stop
         }
         self.ports.update({cp_id: cp_info})
-        if record.get("vld_ref") is not None:
-            pair_id = record.get("vld_ref")
-            self.connect_cp_to_vnetwork(cp_id, pair_id)
+        # if record.get("vld_ref") is not None:
+        #     pair_id = record.get("vld_ref")
+        #     self.connect_cp_to_vnetwork(cp_id, pair_id)
         properties = {
             'int_name': int_name,
             'ext_name':ext_name,

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -1011,9 +1011,9 @@ class LinuxBridge(NetworkPlugin):
 
     def create_port_from_descriptor(self, descriptor):
         cp_uuid = '{}'.format(uuid.uuid4())
-        cp_id = descriptor.get('uuid')
+        cp_id = descriptor.get('id')
         # descriptor = self.agent.get_port_info(record.get('cp_uuid'))
-        cp_small_id = ''.join([x[0] for x in cp_id.split('-')])
+        cp_small_id = ''.join([x[0] for x in cp_uuid.split('-')])
         cp_name = 'br-cp-{}'.format(cp_small_id)
         int_name = 'cp-{}-i'.format(cp_small_id)
         ext_name = 'cp-{}-e'.format(cp_small_id)

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -1010,51 +1010,61 @@ class LinuxBridge(NetworkPlugin):
     # EVAL called by agent for CPs #
 
     def create_port_from_descriptor(self, descriptor):
-        cp_uuid = '{}'.format(uuid.uuid4())
-        cp_id = descriptor.get('id')
-        # descriptor = self.agent.get_port_info(record.get('cp_uuid'))
-        cp_small_id = ''.join([x[0] for x in cp_uuid.split('-')])
-        cp_name = 'br-cp-{}'.format(cp_small_id)
-        int_name = 'cp-{}-i'.format(cp_small_id)
-        ext_name = 'cp-{}-e'.format(cp_small_id)
-        self.logger.info('create_port', 'Creating {} {} {}'.format(cp_name, int_name, ext_name))
-        start_file = self.__generate_port_create_script(int_name, ext_name, cp_name)
-        stop_file = self.__generate_port_destroy_script(ext_name, cp_name)
-        cmd_start = os.path.join(self.BASE_DIR, start_file)
-        cmd_stop = os.path.join(self.BASE_DIR, stop_file)
-        self.os.execute_command(cmd_start,blocking=True, external=True)
-        cp_info = {
-            'descriptor':descriptor,
-            'int_name': int_name,
-            'ext_name':ext_name,
-            'cp_name':cp_name,
-            'start':cmd_start,
-            'stop':cmd_stop
-        }
-        self.ports.update({cp_uuid: cp_info})
-        # if descriptor.get("vld_ref") is not None:
-        #     pair_id = descriptor.get("vld_ref")
-        #     self.connect_cp_to_vnetwork(cp_id, pair_id)
-        properties = {
-            'int_name': int_name,
-            'ext_name':ext_name,
-            'cp_name':cp_name,
-            'start':cmd_start,
-            'stop':cmd_stop
-        }
+        descriptor = json.loads(descriptor)
+        try:
+            cp_uuid = '{}'.format(uuid.uuid4())
+            cp_id = descriptor.get('id')
+            # descriptor = self.agent.get_port_info(record.get('cp_uuid'))
+            cp_small_id = ''.join([x[0] for x in cp_uuid.split('-')])
+            cp_name = 'br-cp-{}'.format(cp_small_id)
+            int_name = 'cp-{}-i'.format(cp_small_id)
+            ext_name = 'cp-{}-e'.format(cp_small_id)
+            self.logger.info('create_port', 'Creating {} {} {}'.format(cp_name, int_name, ext_name))
+            start_file = self.__generate_port_create_script(int_name, ext_name, cp_name)
+            stop_file = self.__generate_port_destroy_script(ext_name, cp_name)
+            cmd_start = os.path.join(self.BASE_DIR, start_file)
+            cmd_stop = os.path.join(self.BASE_DIR, stop_file)
+            self.os.execute_command(cmd_start,blocking=True, external=True)
+            cp_info = {
+                'descriptor':descriptor,
+                'int_name': int_name,
+                'ext_name':ext_name,
+                'cp_name':cp_name,
+                'start':cmd_start,
+                'stop':cmd_stop
+            }
+            self.ports.update({cp_uuid: cp_info})
+            # if descriptor.get("vld_ref") is not None:
+            #     pair_id = descriptor.get("vld_ref")
+            #     self.connect_cp_to_vnetwork(cp_id, pair_id)
+            properties = {
+                'int_name': int_name,
+                'ext_name':ext_name,
+                'cp_name':cp_name,
+                'start':cmd_start,
+                'stop':cmd_stop
+            }
 
-        record = {
-            'uuid':cp_uuid,
-            'cp_id':cp_id,
-            'cp_type':descriptor.get('cp_type'),
-            'vld_ref':descriptor.get('vld_ref'),
-            'port_secutiry_enabled':descriptor.get('port_security_enabled'),
-            'veth_face_name':ext_name,
-            'br_name':properties['cp_name'],
-            'properties':properties
-        }
-        self.connector.loc.actual.add_node_port(self.node, self.uuid, cp_uuid,record)
-        return {'result':record}
+            record = {
+                'uuid':cp_uuid,
+                'cp_id':cp_id,
+                'cp_type':descriptor.get('cp_type'),
+                'vld_ref':descriptor.get('vld_ref'),
+                'port_secutiry_enabled':descriptor.get('port_security_enabled'),
+                'veth_face_name':ext_name,
+                'br_name':properties['cp_name'],
+                'properties':properties,
+                'status':'CREATE'
+            }
+            self.connector.loc.actual.add_node_port(self.node, self.uuid, cp_uuid,record)
+            return {'result':record}
+        except Exception as e:
+            import traceback
+            self.logger.error('create_port_from_descriptor()', '[ERROR] {}'.format(traceback.format_exc()))
+            traceback.format_exc()
+            self.logger.error('create_port_from_descriptor()', '[ERROR] got error {}'.format(e))
+            return {'error':503, 'error_msg':'{}'.format(e)}
+
 
     def destroy_port_agent(self, cp_id):
         port_info = self.ports.get(cp_id)

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -336,9 +336,9 @@ class LinuxBridge(NetworkPlugin):
             'stop':cmd_stop
         }
         self.ports.update({cp_id: cp_info})
-        # if record.get("vld_ref") is not None:
-        #     pair_id = record.get("vld_ref")
-        #     self.connect_cp_to_vnetwork(cp_id, pair_id)
+        if record.get("vld_ref") is not None:
+            pair_id = record.get("vld_ref")
+            self.connect_cp_to_vnetwork(cp_id, pair_id)
         properties = {
             'int_name': int_name,
             'ext_name':ext_name,

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -1013,7 +1013,7 @@ class LinuxBridge(NetworkPlugin):
         descriptor = json.loads(descriptor)
         try:
             cp_uuid = '{}'.format(uuid.uuid4())
-            cp_id = descriptor.get('id')
+            cp_id = descriptor.get('uuid')
             # descriptor = self.agent.get_port_info(record.get('cp_uuid'))
             cp_small_id = ''.join([x[0] for x in cp_uuid.split('-')])
             cp_name = 'br-cp-{}'.format(cp_small_id)

--- a/fos-plugins/linuxbridge/linuxbridge_plugin
+++ b/fos-plugins/linuxbridge/linuxbridge_plugin
@@ -129,7 +129,10 @@ class LinuxBridge(NetworkPlugin):
             'remove_floating_ip': self.remove_floating_ip,
             # utility functions
             'get_overlay_interface': self.get_overlay_face,
-            'get_vlan_interface': self.get_vlan_face
+            'get_vlan_interface': self.get_vlan_face,
+            # fuctions called by agent for CPs
+            'create_port_agent': self.create_port_from_descriptor,
+            'destroy_port_agent':self.destroy_port_agent,
         }
 
         for k in d:
@@ -333,8 +336,8 @@ class LinuxBridge(NetworkPlugin):
             'stop':cmd_stop
         }
         self.ports.update({cp_id: cp_info})
-        if record.get("internal_vld_ref") is not None:
-            pair_id = record.get("internal_vld_ref")
+        if record.get("vld_ref") is not None:
+            pair_id = record.get("vld_ref")
             self.connect_cp_to_vnetwork(cp_id, pair_id)
         properties = {
             'int_name': int_name,
@@ -354,8 +357,8 @@ class LinuxBridge(NetworkPlugin):
             self.logger.error('delete_port','{} does not exist'.format(cp_id))
             return False
         stop_file = port_info.get('stop')
-        if port_info.get('descriptor').get('internal_vld_ref') is not None:
-            pair_id = port_info.get('descriptor').get('internal_vld_ref')
+        if port_info.get('descriptor').get('vld_ref') is not None:
+            pair_id = port_info.get('descriptor').get('vld_ref')
             self.disconnect_cp(cp_id)
         self.os.execute_command(stop_file,blocking=True, external=True)
         self.os.remove_file(stop_file)
@@ -1003,6 +1006,71 @@ class LinuxBridge(NetworkPlugin):
     # ============ #
 
 
+
+    # EVAL called by agent for CPs #
+
+    def create_port_from_descriptor(self, descriptor):
+        cp_uuid = '{}'.format(uuid.uuid4())
+        cp_id = descriptor.get('uuid')
+        # descriptor = self.agent.get_port_info(record.get('cp_uuid'))
+        cp_small_id = ''.join([x[0] for x in cp_id.split('-')])
+        cp_name = 'br-cp-{}'.format(cp_small_id)
+        int_name = 'cp-{}-i'.format(cp_small_id)
+        ext_name = 'cp-{}-e'.format(cp_small_id)
+        self.logger.info('create_port', 'Creating {} {} {}'.format(cp_name, int_name, ext_name))
+        start_file = self.__generate_port_create_script(int_name, ext_name, cp_name)
+        stop_file = self.__generate_port_destroy_script(ext_name, cp_name)
+        cmd_start = os.path.join(self.BASE_DIR, start_file)
+        cmd_stop = os.path.join(self.BASE_DIR, stop_file)
+        self.os.execute_command(cmd_start,blocking=True, external=True)
+        cp_info = {
+            'descriptor':descriptor,
+            'int_name': int_name,
+            'ext_name':ext_name,
+            'cp_name':cp_name,
+            'start':cmd_start,
+            'stop':cmd_stop
+        }
+        self.ports.update({cp_uuid: cp_info})
+        if descriptor.get("vld_ref") is not None:
+            pair_id = descriptor.get("vld_ref")
+            self.connect_cp_to_vnetwork(cp_id, pair_id)
+        properties = {
+            'int_name': int_name,
+            'ext_name':ext_name,
+            'cp_name':cp_name,
+            'start':cmd_start,
+            'stop':cmd_stop
+        }
+
+        record = {
+            'uuid':cp_uuid,
+            'cp_id':cp_id,
+            'cp_type':descriptor.get('cp_type'),
+            'vld_ref':descriptor.get('vld_ref'),
+            'port_secutiry_enabled':descriptor.get('port_security_enabled'),
+            'veth_face_name':ext_name,
+            'br_name':properties['cp_name'],
+            'properties':properties
+        }
+        self.connector.loc.actual.add_node_port(self.node, self.uuid, cp_uuid,record)
+        return {'result':record}
+
+    def destroy_port_agent(self, cp_id):
+        port_info = self.ports.get(cp_id)
+        if port_info is None:
+            self.logger.error('delete_port','{} does not exist'.format(cp_id))
+            return False
+        stop_file = port_info.get('stop')
+        self.os.execute_command(stop_file,blocking=True, external=True)
+        self.os.remove_file(stop_file)
+        self.os.remove_file(port_info.get('start'))
+        self.ports.pop(cp_id)
+        self.connector.loc.actual.remove_node_port(self.node, self.uuid, cp_id)
+        return {'result':port_info}
+
+        # ================================= #
+
     def __get_cp_ip(self, cp_id):
         cp_rec = self.connector.loc.actual.get_node_port(self.node, self.uuid, cp_id)
         self.logger.info('__get_cp_ip()', 'Get connection point IP for {} Record: {}'.format(cp_id, cp_rec))
@@ -1044,7 +1112,7 @@ class LinuxBridge(NetworkPlugin):
         self.logger.info('__get_cp_routers()', 'Scanning FDU Interfaces')
         for c in fdud['connection_points']:
             if c['uuid'] == cp_rec['cp_uuid']:
-                netid = c['internal_vld_ref']
+                netid = c['vld_ref']
 
         self.logger.info('__get_cp_routers()', 'CP is connected to {}'.format(netid))
         if netid is '':

--- a/src/agent/fos-agent.opam
+++ b/src/agent/fos-agent.opam
@@ -31,6 +31,8 @@ depends: [
   "apero-net"
   "yaks-ocaml"
   "fos-core"
+  "fos-fim-api"
+  "fos-faem-api"
 ]
 
 

--- a/src/agent/fos-agent/dune
+++ b/src/agent/fos-agent/dune
@@ -2,6 +2,6 @@
    (name fos_agent)
    (public_name fos_agent)
    (package fos-agent)
-   (libraries cmdliner fos-core fos-fim-api apero-core apero-net yaks-common yaks-ocaml lwt logs logs.fmt logs.cli fmt fmt.cli fmt.tty)
+   (libraries cmdliner fos-core fos-fim-api fos-faem-api apero-core apero-net yaks-common yaks-ocaml lwt logs logs.fmt logs.cli fmt fmt.cli fmt.tty)
    (preprocess (pps lwt_ppx ppx_cstruct ))
 )

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -343,7 +343,15 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     let instance_id = Apero.Option.get @@ Apero.Properties.get "instance_id" props in
     let interface = Apero.Option.get @@ Apero.Properties.get "interface" props in
     try%lwt
-      let%lwt record = Yaks_connector.Global.Actual.get_node_fdu_info sys_id Yaks_connector.default_tenant_id (Apero.Option.get state.configuration.agent.uuid) "*" instance_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
+
+      let%lwt nodeid = Yaks_connector.Global.Actual.get_fdu_instance_node sys_id Yaks_connector.default_tenant_id instance_id state.yaks in
+      let nodeid =
+        match nodeid with
+        | Some nid -> nid
+        | None ->  raise @@ FException (`InternalError (`Msg ("Unable to find nodeid for this instance id" ) ))
+      in
+
+      let%lwt record = Yaks_connector.Global.Actual.get_node_fdu_info sys_id Yaks_connector.default_tenant_id (Apero.Option.get state.configuration.agent.uuid) nodeid instance_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
       (* Find Correct Plugin *)
       let fdu_type = Fos_im.string_of_hv_type record.hypervisor in
       let%lwt plugins = Yaks_connector.Local.Actual.get_node_plugins (Apero.Option.get state.configuration.agent.uuid) state.yaks in
@@ -381,7 +389,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
          Lwt.fail @@ FException (`PluginNotFound (`MsgCode ((Printf.sprintf ("CRITICAL!!!! Cannot find a plugin for this FDU even if it is present in the node WTF!! %s") instance_id ),404))))
     with
     | exn ->
-      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP-TO-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
@@ -392,7 +400,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     let face = Apero.Option.get @@ Apero.Properties.get "interface" props in
     let instance_id = Apero.Option.get @@ Apero.Properties.get "instance_id" props in
     try%lwt
-      let%lwt record = Yaks_connector.Global.Actual.get_node_fdu_info sys_id Yaks_connector.default_tenant_id (Apero.Option.get state.configuration.agent.uuid) "*" instance_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
+
+      let%lwt nodeid = Yaks_connector.Global.Actual.get_fdu_instance_node sys_id Yaks_connector.default_tenant_id instance_id state.yaks in
+      let nodeid =
+        match nodeid with
+        | Some nid -> nid
+        | None ->  raise @@ FException (`InternalError (`Msg ("Unable to find nodeid for this instance id" ) ))
+      in
+      let%lwt record = Yaks_connector.Global.Actual.get_node_fdu_info sys_id Yaks_connector.default_tenant_id (Apero.Option.get state.configuration.agent.uuid) nodeid instance_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
       (* Find Correct Plugin *)
       let fdu_type = Fos_im.string_of_hv_type record.hypervisor in
       let%lwt plugins = Yaks_connector.Local.Actual.get_node_plugins (Apero.Option.get state.configuration.agent.uuid) state.yaks in
@@ -2049,6 +2064,7 @@ let info =
 let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)
 let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)
 
+let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)
 let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)
 let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)
 let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -85,7 +85,7 @@ let main_loop state promise =
 
 let agent verbose_flag debug_flag configuration custom_uuid =
   let level, reporter = (match verbose_flag with
-      | true -> Apero.Result.get @@ Logs.level_of_string "info" ,  (Logs_fmt.reporter ())
+      | true -> Apero.Result.get @@ Logs.level_of_string "debug" ,  (Logs_fmt.reporter ())
       | false -> Apero.Result.get @@ Logs.level_of_string "error",  (Fos_core.get_unix_syslog_reporter ())
     )
   in
@@ -105,19 +105,19 @@ let agent verbose_flag debug_flag configuration custom_uuid =
   let sys_id = Apero.Option.get @@ conf.agent.system in
   let uuid = (Apero.Option.get conf.agent.uuid) in
   let plugin_path = conf.plugins.plugin_path in
-  let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - DEBUG IS: %b"  debug_flag) in
-  let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - ##############") in
-  let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - Agent Configuration is:") in
-  let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - SYSID: %s" sys_id) in
-  let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - UUID: %s"  uuid) in
-  let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - LLDPD: %b" conf.agent.enable_lldp) in
-  let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - SPAWNER: %b" conf.agent.enable_spawner) in
-  let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - PID FILE: %s" conf.agent.pid_file) in
-  let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - YAKS Server: %s" conf.agent.yaks) in
-  let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - MGMT Interface: %s" conf.agent.mgmt_interface) in
-  let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - Plugin Directory: %s" plugin_path) in
-  let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - AUTOLOAD: %b" conf.plugins.autoload) in
-  let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - Plugins:") in
+  let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - DEBUG IS: %b"  debug_flag) in
+  let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - ##############") in
+  let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - Agent Configuration is:") in
+  let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - SYSID: %s" sys_id) in
+  let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - UUID: %s"  uuid) in
+  let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - LLDPD: %b" conf.agent.enable_lldp) in
+  let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - SPAWNER: %b" conf.agent.enable_spawner) in
+  let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - PID FILE: %s" conf.agent.pid_file) in
+  let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - YAKS Server: %s" conf.agent.yaks) in
+  let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - MGMT Interface: %s" conf.agent.mgmt_interface) in
+  let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - Plugin Directory: %s" plugin_path) in
+  let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - AUTOLOAD: %b" conf.plugins.autoload) in
+  let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - Plugins:") in
   List.iter (fun p -> ignore @@ Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - %s" p )) (Apero.Option.get_or_default conf.plugins.auto []);
   (* let sys_info = system_info sys_id uuid in *)
   let%lwt yaks = Yaks_connector.get_connector conf in
@@ -171,10 +171,10 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     let node_uuid = Apero.Option.get @@ Apero.Properties.get "node_uuid" props in
     let instanceid = Apero.Option.get @@ Apero.Properties.get "instance_uuid" props in
     try%lwt
-      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - eval_get_node_fdu_info - Search for FDU Info") in
+      let _ = Logs.debug (fun m -> m "[FOS-AGENT] - eval_get_node_fdu_info - Search for FDU Info") in
       let%lwt descriptor = Yaks_connector.Global.Actual.get_node_fdu_info sys_id Yaks_connector.default_tenant_id node_uuid fdu_uuid instanceid state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
       let js = FAgentTypes.json_of_string @@ Infra.Descriptors.FDU.string_of_record  descriptor in
-      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - eval_get_node_fdu_info - INFO %s" (FAgentTypes.string_of_json js)) in
+      let _ = Logs.debug (fun m -> m "[FOS-AGENT] - eval_get_node_fdu_info - INFO %s" (FAgentTypes.string_of_json js)) in
       let eval_res = FAgentTypes.{result = Some js ; error = None; error_msg = None} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
@@ -200,7 +200,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
   let eval_get_port_info self (props:Apero.properties) =
     MVar.read self >>= fun state ->
     let cp_uuid = Apero.Option.get @@ Apero.Properties.get "cp_uuid" props in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - eval_get_port_info - Getting info for port %s" cp_uuid ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - eval_get_port_info - Getting info for port %s" cp_uuid ) in
     try%lwt
       let%lwt descriptor = Yaks_connector.Global.Actual.get_port sys_id Yaks_connector.default_tenant_id cp_uuid state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
       let js = FAgentTypes.json_of_string @@ User.Descriptors.Network.string_of_connection_point_descriptor  descriptor in
@@ -208,12 +208,12 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
     | _ ->
-      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - eval_get_port_info - Search port on FDU") in
+      let _ = Logs.debug (fun m -> m "[FOS-AGENT] - eval_get_port_info - Search port on FDU") in
       let%lwt fdu_ids = Yaks_connector.Global.Actual.get_catalog_all_fdus sys_id Yaks_connector.default_tenant_id state.yaks in
       let%lwt cps = Lwt_list.filter_map_p (fun e ->
           let%lwt fdu =  Yaks_connector.Global.Actual.get_catalog_fdu_info sys_id Yaks_connector.default_tenant_id e state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
           let%lwt c = Lwt_list.filter_map_p (fun (cp:User.Descriptors.Network.connection_point_descriptor) ->
-              let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - eval_get_port_info - %s == %s ? %d " cp.id cp_uuid (String.compare cp.id  cp_uuid)) in
+              let _ = Logs.debug (fun m -> m "[FOS-AGENT] - eval_get_port_info - %s == %s ? %d " cp.id cp_uuid (String.compare cp.id  cp_uuid)) in
               if (String.compare cp.id cp_uuid) == 0 then  Lwt.return @@ Some cp
               else Lwt.return None
             ) fdu.connection_points
@@ -259,8 +259,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     MVar.read self >>= fun state ->
     try%lwt
       let%lwt net_p = get_network_plugin self in
-      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-NET - ##############") in
-      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-NET - Properties: %s" (Apero.Properties.to_string props) ) in
+      let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-NET - ##############") in
+      let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-NET - Properties: %s" (Apero.Properties.to_string props) ) in
       let descriptor = FTypes.virtual_network_of_string @@ Apero.Option.get @@ Apero.Properties.get "descriptor" props in
       let record = FTypesRecord.{uuid = descriptor.uuid; status = `CREATE; properties = None; ip_configuration = descriptor.ip_configuration; overlay = None; vni = None; mcast_addr = None; vlan_id = None; face = None} in
       Yaks_connector.Local.Desired.add_node_network (Apero.Option.get state.configuration.agent.uuid) net_p descriptor.uuid record state.yaks
@@ -270,7 +270,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-CREATE-NET - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-CREATE-NET - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
@@ -278,8 +278,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     MVar.read self >>= fun state ->
     try%lwt
       let%lwt net_p = get_network_plugin self in
-      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-NET - ##############") in
-      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-NET - Properties: %s" (Apero.Properties.to_string props) ) in
+      let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-NET - ##############") in
+      let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-NET - Properties: %s" (Apero.Properties.to_string props) ) in
       let net_id =Apero.Option.get @@ Apero.Properties.get "net_id" props in
       let%lwt record =  Yaks_connector.Local.Actual.get_node_network  (Apero.Option.get state.configuration.agent.uuid) net_p net_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
       Yaks_connector.Global.Actual.remove_network sys_id Yaks_connector.default_tenant_id record.uuid state.yaks >>= Lwt.return
@@ -289,17 +289,17 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   let eval_create_cp self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let%lwt net_p = get_network_plugin self in
     let descriptor = User.Descriptors.Network.connection_point_descriptor_of_string @@ Apero.Option.get @@ Apero.Properties.get "descriptor" props in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - # NetManager: %s" net_p) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - # NetManager: %s" net_p) in
     try%lwt
       let parameters = [("descriptor",User.Descriptors.Network.string_of_connection_point_descriptor descriptor)] in
       let fname = "create_port_agent" in
@@ -310,17 +310,17 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       | None ->  Lwt.fail @@ FException (`InternalError (`MsgCode ((Printf.sprintf ("Cannot connect create cp %s") descriptor.id ),503)))
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   let eval_remove_cp self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let%lwt net_p = get_network_plugin self in
     let cp_id =  Apero.Option.get @@ Apero.Properties.get "cp_id" props in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - # NetManager: %s" net_p) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - # NetManager: %s" net_p) in
     try%lwt
       let parameters = [("cp_id", cp_id)] in
       let fname = "destroy_port_agent" in
@@ -331,13 +331,13 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       | None ->  Lwt.fail @@ FException (`InternalError (`MsgCode ((Printf.sprintf ("Cannot destroy create cp %s") cp_id ),503)))
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   let eval_connect_cp_to_fdu_face self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP-TO-FDU - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP-TO-FDU - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP-TO-FDU - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP-TO-FDU - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let cp_id = Apero.Option.get @@ Apero.Properties.get "cp_id" props in
     let instance_id = Apero.Option.get @@ Apero.Properties.get "instance_id" props in
@@ -381,13 +381,13 @@ let agent verbose_flag debug_flag configuration custom_uuid =
          Lwt.fail @@ FException (`PluginNotFound (`MsgCode ((Printf.sprintf ("CRITICAL!!!! Cannot find a plugin for this FDU even if it is present in the node WTF!! %s") instance_id ),404))))
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   let eval_disconnect_cp_from_fdu_face self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP-TO-FDU - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP-TO-FDU - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP-TO-FDU - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP-TO-FDU - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let face = Apero.Option.get @@ Apero.Properties.get "interface" props in
     let instance_id = Apero.Option.get @@ Apero.Properties.get "instance_id" props in
@@ -429,18 +429,18 @@ let agent verbose_flag debug_flag configuration custom_uuid =
          Lwt.fail @@ FException (`PluginNotFound (`MsgCode ((Printf.sprintf ("CRITICAL!!!! Cannot find a plugin for this FDU even if it is present in the node WTF!! %s") instance_id ),404))))
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   let eval_connect_cp_to_network self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let%lwt net_p = get_network_plugin self in
     let cp_id = Apero.Option.get @@ Apero.Properties.get "cp_uuid" props in
     let net_id = Apero.Option.get @@ Apero.Properties.get "network_uuid" props in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP - # NetManager: %s" net_p) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP - # NetManager: %s" net_p) in
     try%lwt
       let parameters = [("cp_id",cp_id);("vnet_id", net_id)] in
       let fname = "connect_cp_to_vnetwork" in
@@ -456,12 +456,12 @@ let agent verbose_flag debug_flag configuration custom_uuid =
   in
   (*  *)
   let eval_remove_cp_from_network self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let%lwt net_p = get_network_plugin self in
     let cp_id = Apero.Option.get @@ Apero.Properties.get "cp_uuid" props in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP - # NetManager: %s" net_p) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP - # NetManager: %s" net_p) in
     try%lwt
       let parameters = [("cp_id",cp_id)] in
       let fname = "disconnect_cp" in
@@ -477,8 +477,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
   in
   (* FDU Onboard in Catalog -- this may be moved to Orchestration part *)
   let eval_onboard_fdu self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-ONBOARD-FDU - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-ONBOARD-FDU - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-ONBOARD-FDU - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-ONBOARD-FDU - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let descriptor = Apero.Option.get @@ Apero.Properties.get "descriptor" props in
     try%lwt
@@ -497,14 +497,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-ONBOARD-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-ONBOARD-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error = Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   (* FDU Definition in Node *)
   let eval_define_fdu self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let fdu_uuid = Apero.Option.get @@ Apero.Properties.get "fdu_id" props in
     try%lwt
@@ -617,7 +617,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
          Lwt.fail @@ FException (`PluginNotFound (`MsgCode ((Printf.sprintf ("Node %s has no plugin for %s") (Apero.Option.get state.configuration.agent.uuid) fdu_uuid ),404))))
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
@@ -641,8 +641,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
 
   *)
   let eval_check_fdu self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CHECK-FDU - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CHECK-FDU - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CHECK-FDU - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CHECK-FDU - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let descriptor = Apero.Option.get @@ Apero.Properties.get "descriptor" props in
     try%lwt
@@ -666,9 +666,9 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           | [] -> false
           | _ -> true
         in
-        let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CHECK-FDU - CPU Arch Check: %s = %s ? %b" fdu_cp.cpu_arch ncpu.arch ((String.compare fdu_cp.cpu_arch ncpu.arch) == 0) ) in
-        let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CHECK-FDU - RAM Size Check: %b" (fdu_cp.ram_size_mb <= ninfo.ram.size) ) in
-        let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CHECK-FDU - Plugin Check: %b" has_plugin ) in
+        let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CHECK-FDU - CPU Arch Check: %s = %s ? %b" fdu_cp.cpu_arch ncpu.arch ((String.compare fdu_cp.cpu_arch ncpu.arch) == 0) ) in
+        let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CHECK-FDU - RAM Size Check: %b" (fdu_cp.ram_size_mb <= ninfo.ram.size) ) in
+        let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-CHECK-FDU - Plugin Check: %b" has_plugin ) in
         match ((String.compare fdu_cp.cpu_arch ncpu.arch) == 0),(fdu_cp.ram_size_mb <= ninfo.ram.size), has_plugin with
         | (true, true, true) -> Lwt.return true
         | (_,_,_) -> Lwt.return false
@@ -683,14 +683,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-CHECK-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-CHECK-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg =  None} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   (* Entity Onboard in Catalog *)
   let eval_onboard_entity self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-ONBOARD-ENTITY - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-ONBOARD-ENTITY - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-ONBOARD-ENTITY - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-ONBOARD-ENTITY - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let descriptor = Apero.Option.get @@ Apero.Properties.get "descriptor" props in
     try%lwt
@@ -724,14 +724,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-ONBOARD-ENTITY - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-ONBOARD-ENTITY - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   (* Entity offload from Catalog *)
   let eval_offload_entity self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-OFFLOAD-ENTITY - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-OFFLOAD-ENTITY - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-OFFLOAD-ENTITY - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-OFFLOAD-ENTITY - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let ae_id = Apero.Option.get @@ Apero.Properties.get "entity_id" props in
     try%lwt
@@ -748,14 +748,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
         Lwt.fail @@ FException (`NotFound (`MsgCode (( Printf.sprintf ("Entity %s not in catalog") ae_id ),404)))
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-OFFLOAD-ENTITY - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-OFFLOAD-ENTITY - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error = Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   (* Atomic Entity Onboard in Catalog -- this may be moved to Orchestration part *)
   let eval_onboard_ae self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-ONBOARD-AE - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-ONBOARD-AE - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-ONBOARD-AE - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-ONBOARD-AE - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let descriptor = Apero.Option.get @@ Apero.Properties.get "descriptor" props in
     try%lwt
@@ -774,14 +774,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-ONBOARD-AE - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-ONBOARD-AE - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error = Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   (* EVAL Offload AE *)
   let eval_offload_ae self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-OFFLOAD-AE - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-OFFLOAD-AE - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-OFFLOAD-AE - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-OFFLOAD-AE - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let ae_id = Apero.Option.get @@ Apero.Properties.get "ae_id" props in
     try%lwt
@@ -798,14 +798,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
         Lwt.fail @@ FException (`NotFound (`MsgCode ((Printf.sprintf ("Atomic Entity %s not found") ae_id ),404)))
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-OFFLOAD-AE - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-OFFLOAD-AE - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error = Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   (* EVAL Instantiate an Entity *)
   let eval_instantiate_entity self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-ENTITY - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-ENTITY - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-ENTITY - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-ENTITY - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let e_uuid = Apero.Option.get @@ Apero.Properties.get "entity_id" props in
     try%lwt
@@ -920,14 +920,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
 
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-ENTITY - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-ENTITY - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error = Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   (* EVAL Terminate an AE *)
   let eval_terminate_entity self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-TERMINATE-AE - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-TERMINATE-AE - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-TERMINATE-AE - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-TERMINATE-AE - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     (* let ae_id = Apero.Option.get @@ Apero.Properties.get "ae_id" props in *)
     let e_instance_id = Apero.Option.get @@ Apero.Properties.get "instance_id" props in
@@ -950,14 +950,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
 
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-TERMINATE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-TERMINATE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error = Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   (* EVAL Instantiate an AE  *)
   let eval_instantiate_ae self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-AE - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-AE - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-AE - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-AE - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let ae_uuid = Apero.Option.get @@ Apero.Properties.get "ae_id" props in
     try%lwt
@@ -1123,7 +1123,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
                 (match List.find_opt (fun (e:User.Descriptors.Network.connection_point_descriptor) -> (String.compare ecp e.id)==0) descriptor.connection_points with
                  | Some ae_ecp ->
                    let%lwt cpr = Fos_fim_api.Network.add_connection_point_to_node ae_ecp n state.fim_api in
-                   let%lwt _ = Logs_lwt.info (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-AE - CONNECTING A INTERFACE TO AN EXTERNAL CP : %s <-> %s:%s" cpr.uuid fdur.uuid iface.name ) in
+                   let _ = Logs.info (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-AE - CONNECTING A INTERFACE TO AN EXTERNAL CP : %s <-> %s:%s" cpr.uuid fdur.uuid iface.name ) in
                    Fos_fim_api.FDU.connect_interface_to_cp cpr.uuid fdur.uuid iface.name n state.fim_api
                    >>= fun _ -> Lwt.return (Some cpr)
                  | None ->Lwt.fail @@ FException (`NotFound (`MsgCode (( Printf.sprintf ("Unable to find Atomic entity connection point %s") ecp ),404) ))
@@ -1179,14 +1179,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
 
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error = Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   (* EVAL Terminate an AE *)
   let eval_terminate_ae self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-TERMINATE-AE - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-TERMINATE-AE - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-TERMINATE-AE - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-TERMINATE-AE - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     (* let ae_id = Apero.Option.get @@ Apero.Properties.get "ae_id" props in *)
     let ae_instance_id = Apero.Option.get @@ Apero.Properties.get "instance_id" props in
@@ -1210,25 +1210,25 @@ let agent verbose_flag debug_flag configuration custom_uuid =
 
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-TERMINATE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-TERMINATE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error = Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   (*     NM Floating IPs *)
   let eval_create_floating_ip self (props:Apero.properties) =
     ignore props;
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-NEW-FLOATING-IP - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-NEW-FLOATING-IP - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-NEW-FLOATING-IP - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-NEW-FLOATING-IP - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let%lwt net_p = get_network_plugin self in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-NEW-FLOATING-IP - # NetManager: %s" net_p) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-NEW-FLOATING-IP - # NetManager: %s" net_p) in
     try%lwt
       let fname = "create_floating_ip" in
       Yaks_connector.Local.Actual.exec_nm_eval (Apero.Option.get state.configuration.agent.uuid) net_p fname [] state.yaks
       >>= fun res ->
       match res with
       | Some r ->
-        let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-NEW-FLOATING-IP - GOT RESPONSE FROM EVAL %s" (FAgentTypes.string_of_eval_result r)) in
+        let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-NEW-FLOATING-IP - GOT RESPONSE FROM EVAL %s" (FAgentTypes.string_of_eval_result r)) in
         (* Convertion from record *)
         let floating_r = FTypes.floating_ip_record_of_string @@ JSON.to_string (Apero.Option.get r.result) in
         let floating = FTypes.{uuid = floating_r.uuid; ip_version = floating_r.ip_version; address = floating_r.address} in
@@ -1240,15 +1240,15 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     with
     | exn ->
       let eval_res = FAgentTypes.{result = None ; error = Some 22; error_msg = Some (Printexc.to_string exn)} in
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-NEW-FLOATING-IP - # ERROR WHEN CREATING FLOATING IP") in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-NEW-FLOATING-IP - # ERROR WHEN CREATING FLOATING IP") in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   let eval_delete_floating_ip self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEL-FLOATING-IP - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEL-FLOATING-IP - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DEL-FLOATING-IP - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DEL-FLOATING-IP - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let%lwt net_p = get_network_plugin self in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEL-FLOATING-IP - # NetManager: %s" net_p) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DEL-FLOATING-IP - # NetManager: %s" net_p) in
     try%lwt
       let ip_id = Apero.Option.get @@ Apero.Properties.get "floating_uuid" props in
       let parameters = [("ip_id",ip_id)] in
@@ -1257,7 +1257,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       >>= fun res ->
       match res with
         Some r ->
-        let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEL-FLOATING-IP - GOT RESPONSE FROM EVAL %s" (FAgentTypes.string_of_eval_result r)) in
+        let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DEL-FLOATING-IP - GOT RESPONSE FROM EVAL %s" (FAgentTypes.string_of_eval_result r)) in
         (* Convertion from record *)
         let floating_r = FTypes.floating_ip_record_of_string @@ JSON.to_string (Apero.Option.get r.result) in
         let floating = FTypes.{uuid = floating_r.uuid; ip_version = floating_r.ip_version; address = floating_r.address} in
@@ -1271,14 +1271,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       let msg = Printexc.to_string e
       and stack = Printexc.get_backtrace () in
       Printf.eprintf "there was an error: %s%s\n" msg stack;
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-NEW-FLOATING-IP - # ERROR WHEN DELETING FLOATING IP") in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-NEW-FLOATING-IP - # ERROR WHEN DELETING FLOATING IP") in
       let eval_res = FAgentTypes.{result = None ; error = Some 22; error_msg = Some (Printexc.to_string e)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   (*  *)
   let eval_assign_floating_ip self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-ASSOC-FLOATING-IP - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-ASSOC-FLOATING-IP - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-ASSOC-FLOATING-IP - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-ASSOC-FLOATING-IP - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let%lwt net_p = get_network_plugin self in
     try%lwt
@@ -1301,12 +1301,12 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     with
     | exn ->
       let eval_res = FAgentTypes.{result = None ; error = Some 33; error_msg = Some (Printexc.to_string exn)} in
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-ASSOC-FLOATING-IP - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-ASSOC-FLOATING-IP - EXCEPTION: %s" (Printexc.to_string exn)) in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   let eval_remove_floating_ip self (props:Apero.properties) =
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-FLOATING-IP - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-FLOATING-IP - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-FLOATING-IP - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-FLOATING-IP - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let%lwt net_p = get_network_plugin self in
     try%lwt
@@ -1329,16 +1329,16 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     with
     | exn ->
       let eval_res = FAgentTypes.{result = None ; error = Some 33; error_msg = Some (Printexc.to_string exn)} in
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-REMOVE-FLOATING-IP - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-REMOVE-FLOATING-IP - EXCEPTION: %s" (Printexc.to_string exn)) in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   let eval_add_router_port self (props:Apero.properties) =
     ignore props;
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-ADD-ROUTER-PORT - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-ADD-ROUTER-PORT - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-ADD-ROUTER-PORT - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-ADD-ROUTER-PORT - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let%lwt net_p = get_network_plugin self in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-ADD-ROUTER-PORT - # NetManager: %s" net_p) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-ADD-ROUTER-PORT - # NetManager: %s" net_p) in
     try%lwt
       let fname = "add_router_port" in
       let rid = Apero.Option.get @@ Apero.Properties.get "router_id" props in
@@ -1358,7 +1358,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       >>= fun res ->
       match res with
       | Some r ->
-        let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-ADD-ROUTER-PORT - GOT RESPONSE FROM EVAL %s" (FAgentTypes.string_of_eval_result r)) in
+        let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-ADD-ROUTER-PORT - GOT RESPONSE FROM EVAL %s" (FAgentTypes.string_of_eval_result r)) in
         (* Convertion from record *)
         let router = Router.record_of_string @@ JSON.to_string (Apero.Option.get r.result) in
         let%lwt ports = Lwt_list.map_p (fun (e:Router.router_port_record) ->
@@ -1374,18 +1374,18 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       |  None ->  Lwt.fail @@ FException (`InternalError (`MsgCode ((Printf.sprintf ("Cannot create to router  %s") rid ),503)))
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-ADD-ROUTER-PORT - # ERROR WHEN ADDING ROUTER PORT: %s" (Printexc.to_string exn) ) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-ADD-ROUTER-PORT - # ERROR WHEN ADDING ROUTER PORT: %s" (Printexc.to_string exn) ) in
       let eval_res = FAgentTypes.{result = None ; error = Some 22; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   (*  *)
   let eval_remove_router_port self (props:Apero.properties) =
     ignore props;
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEL-ROUTER-PORT - ##############") in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEL-ROUTER-PORT - Properties: %s" (Apero.Properties.to_string props) ) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DEL-ROUTER-PORT - ##############") in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DEL-ROUTER-PORT - Properties: %s" (Apero.Properties.to_string props) ) in
     MVar.read self >>= fun state ->
     let%lwt net_p = get_network_plugin self in
-    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEL-ROUTER-PORT - # NetManager: %s" net_p) in
+    let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DEL-ROUTER-PORT - # NetManager: %s" net_p) in
     try%lwt
       let fname = "remove_router_port" in
       let rid = Apero.Option.get @@ Apero.Properties.get "router_id" props in
@@ -1395,7 +1395,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       >>= fun res ->
       match res with
       | Some r ->
-        let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEL-ROUTER-PORT - GOT RESPONSE FROM EVAL %s" (FAgentTypes.string_of_eval_result r)) in
+        let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DEL-ROUTER-PORT - GOT RESPONSE FROM EVAL %s" (FAgentTypes.string_of_eval_result r)) in
         (* Convertion from record *)
         let router = Router.record_of_string @@ JSON.to_string (Apero.Option.get r.result) in
         let%lwt ports = Lwt_list.map_p (fun (e:Router.router_port_record) ->
@@ -1411,7 +1411,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       |  None ->  Lwt.fail @@ FException (`InternalError (`MsgCode ((Printf.sprintf ("Cannot remove port from router %s") rid ),503)))
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-DEL-ROUTER-PORT - # ERROR WHEN REMOVING ROUTER PORT: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-DEL-ROUTER-PORT - # ERROR WHEN REMOVING ROUTER PORT: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error = Some 22; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
@@ -1423,10 +1423,10 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match pl with
        | Some pl ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-PLUGIN - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-PLUGIN - Received plugin") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-PLUGIN - Name: %s" pl.name) in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-PLUGIN -  Calling the spawner by writing this on local desired") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-PLUGIN - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-PLUGIN - Received plugin") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-PLUGIN - Name: %s" pl.name) in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-PLUGIN -  Calling the spawner by writing this on local desired") in
          Yaks_connector.Local.Desired.add_node_plugin (Apero.Option.get self.configuration.agent.uuid) pl self.yaks >>= Lwt.return
        | None -> Lwt.return_unit)
     | true ->
@@ -1441,8 +1441,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     | false ->
       (match fdu with
        | Some fdu -> MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-FDU - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-FDU - FDU Updated! Advertising on GA") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-FDU - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-FDU - FDU Updated! Advertising on GA") in
          let fdu =
            match fdu.uuid with
            | Some _ -> fdu
@@ -1465,8 +1465,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match img with
        | Some img ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-IMAGE - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-IMAGE - Image Updated! Advertising on GA") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-IMAGE - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-IMAGE - Image Updated! Advertising on GA") in
          (match img.uuid with
           | Some id -> Yaks_connector.Global.Actual.add_image sys_id Yaks_connector.default_tenant_id id img self.yaks >>= Lwt.return
           | None -> Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-IMAGE - Ignoring Image as UUID is missing!!") >>= Lwt.return)
@@ -1484,8 +1484,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match flv with
        | Some flv ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-FLAVOR - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-FLAVOR - Flavor Updated! Advertising on GA") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-FLAVOR - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-FLAVOR - Flavor Updated! Advertising on GA") in
          (match flv.uuid with
           | Some id -> Yaks_connector.Global.Actual.add_flavor sys_id Yaks_connector.default_tenant_id id flv self.yaks >>= Lwt.return
           | None -> Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-FLAVOR - Ignoring Flavor as UUID is missing!!") >>= Lwt.return)
@@ -1503,11 +1503,11 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match fdu with
        | Some fdu ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NODE-FDU - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NODE-FDU - FDU Updated! Agent will call the right plugin!") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-NODE-FDU - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-NODE-FDU - FDU Updated! Agent will call the right plugin!") in
          let%lwt fdu_d = Yaks_connector.Global.Actual.get_catalog_fdu_info sys_id Yaks_connector.default_tenant_id fdu.fdu_id self.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
          let fdu_type = Fos_im.string_of_hv_type fdu_d.hypervisor in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-FDU - FDU Type %s" fdu_type) in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-FDU - FDU Type %s" fdu_type) in
          let%lwt plugins = Yaks_connector.Local.Actual.get_node_plugins (Apero.Option.get self.configuration.agent.uuid) self.yaks in
          let%lwt matching_plugins = Lwt_list.filter_map_p (fun e ->
              let%lwt pl = Yaks_connector.Local.Actual.get_node_plugin (Apero.Option.get self.configuration.agent.uuid) e self.yaks in
@@ -1519,16 +1519,16 @@ let agent verbose_flag debug_flag configuration custom_uuid =
          in
          (match matching_plugins with
           | [] ->
-            let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - CB-GD-FDU - No plugin found for this FDU") in
+            let _ = Logs.err (fun m -> m "[FOS-AGENT] - CB-GD-FDU - No plugin found for this FDU") in
             let r = { fdu with status = `ERROR} in
             Yaks_connector.Global.Actual.add_node_fdu sys_id Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) r.fdu_id r.uuid r self.yaks >>= Lwt.return
           | _ ->
             let pl = List.hd matching_plugins in
-            let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-FDU - Calling %s plugin" pl.name) in
+            let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-FDU - Calling %s plugin" pl.name) in
             (* Here we should at least update the record interfaces and connection points *)
             match fdu.status with
             | `DEFINE ->
-              let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - CB-GD-FDU - FDU Define it is not supposed to pass by this function") in
+              let _ = Logs.err (fun m -> m "[FOS-AGENT] - CB-GD-FDU - FDU Define it is not supposed to pass by this function") in
               Lwt.return_unit
             | _ -> Yaks_connector.Local.Desired.add_node_fdu (Apero.Option.get self.configuration.agent.uuid) pl.uuid fdu.fdu_id fdu.uuid fdu self.yaks >>= Lwt.return
          )
@@ -1549,8 +1549,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match net with
        | Some net ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET Updated! Agent will update actual store and call the right plugin!") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET Updated! Agent will update actual store and call the right plugin!") in
          let%lwt _ = Yaks_connector.Global.Actual.add_network sys_id Yaks_connector.default_tenant_id net.uuid net self.yaks in
          (* let record = FTypesRecord.{uuid = net.uuid; status = `CREATE; properties = None; ip_configuration = net.ip_configuration; overlay = None; vni = None; mcast_addr = None; vlan_id = None; face = None} in *)
          (* Yaks_connector.Local.Desired.add_node_network (Apero.Option.get self.configuration.agent.uuid) net_p net.uuid record self.yaks *)
@@ -1559,14 +1559,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     | true ->
       (match uuid with
        | Some netid -> MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET Removed!") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET Removed!") in
          let%lwt net_info = Yaks_connector.Local.Actual.get_node_network (Apero.Option.get self.configuration.agent.uuid) net_p netid self.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
          let net_info = {net_info with status = `DESTROY} in
          let%lwt _ = Yaks_connector.Local.Desired.add_node_network (Apero.Option.get self.configuration.agent.uuid) net_p netid net_info self.yaks in
          Yaks_connector.Global.Actual.remove_network sys_id Yaks_connector.default_tenant_id netid self.yaks >>= Lwt.return
        | None ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET NO UUID!!!!") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET NO UUID!!!!") in
          Lwt.return_unit)
 
   in
@@ -1578,8 +1578,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match net with
        | Some net ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET Updated! Agent will update actual store and call the right plugin!") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET Updated! Agent will update actual store and call the right plugin!") in
          (* let%lwt _ = Yaks_connector.Global.Actual.add_network sys_id Yaks_connector.default_tenant_id net.uuid net self.yaks in *)
          (* let record = FTypesRecord.{uuid = net.uuid; status = `CREATE; properties = None; ip_configuration = net.ip_configuration} in *)
          Yaks_connector.Local.Desired.add_node_network (Apero.Option.get self.configuration.agent.uuid) net_p net.uuid net self.yaks
@@ -1588,14 +1588,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     | true ->
       (match uuid with
        | Some netid -> MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET Removed!") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET Removed!") in
          let%lwt net_info = Yaks_connector.Local.Actual.get_node_network (Apero.Option.get self.configuration.agent.uuid) net_p netid self.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
          let net_info = {net_info with status = `DESTROY} in
          let%lwt _ = Yaks_connector.Local.Desired.add_node_network (Apero.Option.get self.configuration.agent.uuid) net_p netid net_info self.yaks in
          Yaks_connector.Global.Actual.remove_network sys_id Yaks_connector.default_tenant_id netid self.yaks >>= Lwt.return
        | None ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET NO UUID!!!!") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET NO UUID!!!!") in
          Lwt.return_unit)
 
   in
@@ -1606,8 +1606,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       ( match cp with
         | Some cp ->
           MVar.read self >>= fun self ->
-          let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-CP - ##############") in
-          let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-CP - CP Updated! Agent will update actual store and call the right plugin!") in
+          let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-CP - ##############") in
+          let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-CP - CP Updated! Agent will update actual store and call the right plugin!") in
           let%lwt _ = Yaks_connector.Global.Actual.add_port sys_id Yaks_connector.default_tenant_id cp.id cp self.yaks in
           let record = Infra.Descriptors.Network.{cp_id = cp.id; uuid = cp.id; status = `CREATE; properties = None; veth_face_name = None; br_name = None;cp_type= Some `VPORT; port_security_enabled=None; vld_ref = cp.vld_ref} in
           Yaks_connector.Local.Desired.add_node_port (Apero.Option.get self.configuration.agent.uuid) net_p record.uuid record self.yaks
@@ -1627,8 +1627,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match router with
        | Some router ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-ROUTER - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-ROUTER - vRouter Updated! Agent will update actual store and call the right plugin!") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-ROUTER - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-ROUTER - vRouter Updated! Agent will update actual store and call the right plugin!") in
          (* Converting to record *)
          let rid = (Apero.Option.get_or_default router.uuid (Apero.Uuid.to_string (Apero.Uuid.make ()))) in
          let%lwt port_records = Lwt_list.mapi_p (fun i (e:Router.router_port) ->
@@ -1654,14 +1654,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     | true ->
       (match uuid with
        | Some routerid -> MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-ROUTER - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-ROUTER - vRouter Removed!") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-ROUTER - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-ROUTER - vRouter Removed!") in
          let%lwt router_info = Yaks_connector.Local.Actual.get_node_router (Apero.Option.get self.configuration.agent.uuid) net_p routerid self.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
          let router_info = {router_info with state = `DESTROY} in
          Yaks_connector.Local.Desired.add_node_router (Apero.Option.get self.configuration.agent.uuid) net_p routerid router_info self.yaks
        (* Yaks_connector.Global.Actual.reove_ sys_id Yaks_connector.default_tenant_id routerid self.yaks >>= Lwt.return *)
        | None ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-ROUTER - vRouter NO UUID!!!!") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-ROUTER - vRouter NO UUID!!!!") in
          Lwt.return_unit)
 
   in
@@ -1673,8 +1673,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match net with
        | Some net ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-NET - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-NET - vNET Updated! Advertising on GA") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-NET - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-NET - vNET Updated! Advertising on GA") in
          let nid = (Apero.Option.get self.configuration.agent.uuid) in
          (match net.status with
           | `DESTROY -> Yaks_connector.Global.Actual.remove_node_network sys_id Yaks_connector.default_tenant_id nid net.uuid self.yaks
@@ -1695,8 +1695,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match cp with
        | Some cp ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-CP - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-CP - CP Updated! Advertising on GA") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-CP - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-CP - CP Updated! Advertising on GA") in
          let nid = (Apero.Option.get self.configuration.agent.uuid) in
          ( match cp.status with
            | `DESTROY -> Yaks_connector.Global.Actual.remove_node_port sys_id Yaks_connector.default_tenant_id nid cp.cp_id self.yaks
@@ -1718,8 +1718,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match router with
        | Some router ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-ROUTER - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-ROUTER - vRouter Updated! Advertising on GA") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-ROUTER - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-ROUTER - vRouter Updated! Advertising on GA") in
          let nid = (Apero.Option.get self.configuration.agent.uuid) in
          (match router.state with
           | `DESTROY -> Yaks_connector.Global.Actual.remove_node_router sys_id Yaks_connector.default_tenant_id nid router.uuid self.yaks
@@ -1745,10 +1745,10 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match pl with
        | Some pl ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-PLUGIN - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-PLUGIN - Received plugin") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-PLUGIN - Name: %s" pl.name) in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-PLUGIN -  Plugin loaded advertising on GA") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-PLUGIN - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-PLUGIN - Received plugin") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-PLUGIN - Name: %s" pl.name) in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-PLUGIN -  Plugin loaded advertising on GA") in
          Yaks_connector.Global.Actual.add_node_plugin sys_id Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) pl self.yaks >>= Lwt.return
        | None -> Lwt.return_unit)
     | true ->
@@ -1764,8 +1764,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match ni with
        | Some ni ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-NI - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-NI - Updated node info advertising of GA") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-NI - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-NI - Updated node info advertising of GA") in
          Yaks_connector.Global.Actual.add_node_info sys_id Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) ni self.yaks >>= Lwt.return
        | None -> Lwt.return_unit)
     | true ->
@@ -1781,8 +1781,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match ns with
        | Some ns ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-NI - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-NI - Updated node info advertising of GA") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-NI - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-NI - Updated node info advertising of GA") in
          Yaks_connector.Global.Actual.add_node_status sys_id Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) ns self.yaks >>= Lwt.return
        | None -> Lwt.return_unit)
     | true ->
@@ -1797,8 +1797,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match fdu with
        | Some fdu ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-NODE-FDU - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LA-NODE-FDU - FDU Updated! Advertising on GA") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-NODE-FDU - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LA-NODE-FDU - FDU Updated! Advertising on GA") in
          ( match fdu.status with
            | `UNDEFINE -> Yaks_connector.Global.Actual.remove_node_fdu sys_id Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) fdu.fdu_id fdu.uuid self.yaks
            | _ ->
@@ -1819,16 +1819,16 @@ let agent verbose_flag debug_flag configuration custom_uuid =
      (match fdu with
      | Some fdu ->
      MVar.read self >>= fun self ->
-     let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-CNODE-FDU - ##############") in
-     let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-CNODE-FDU - FDU Updated! Agent will call the right plugin!") in
+     let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-CNODE-FDU - ##############") in
+     let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-CNODE-FDU - FDU Updated! Agent will call the right plugin!") in
      let%lwt fdu_d = Yaks_connector.Global.Actual.get_fdu_info sys_id Yaks_connector.default_tenant_id fdu.fdu_uuid self.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
      let fdu_type = Fos_im.string_of_hv_type fdu_d.hypervisor in
-     let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-CNODE-FDU - FDU Type %s" fdu_type) in
+     let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-CNODE-FDU - FDU Type %s" fdu_type) in
      let%lwt plugins = Yaks_connector.LocalConstraint.Actual.get_node_plugins nodeid self.yaks in
      Lwt_list.iter_p (fun e ->
      let%lwt pl = Yaks_connector.LocalConstraint.Actual.get_node_plugin nodeid e self.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
      if String.uppercase_ascii (pl.name) = String.uppercase_ascii (fdu_type) then
-     let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-FDU - Calling %s plugin" pl.name) in
+     let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-FDU - Calling %s plugin" pl.name) in
      Yaks_connector.LocalConstraint.Desired.add_node_fdu nodeid pl.uuid fdu.fdu_uuid fdu self.yaks >>= Lwt.return
      else
      Lwt.return_unit
@@ -1848,8 +1848,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match fdu with
        | Some fdu ->
          MVar.read self >>= fun _ ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NODE-FDU - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NODE-FDU - FDU Updated! Advertising on GA") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NODE-FDU - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NODE-FDU - FDU Updated! Advertising on GA") in
          ( match fdu.status with
            | `UNDEFINE -> Lwt.return_unit
            (* Yaks_connector.Global.Actual.remove_node_fdu sys_id Yaks_connector.default_tenant_id nodeid fdu.fdu_uuid self.yaks *)
@@ -1868,10 +1868,10 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match pl with
        | Some pl ->
          MVar.read self >>= fun self ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LAC-PLUGIN - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LAC-PLUGIN - Received plugin") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LAC-PLUGIN - Name: %s" pl.name) in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LAC-PLUGIN -  Plugin loaded advertising on GA") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LAC-PLUGIN - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LAC-PLUGIN - Received plugin") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LAC-PLUGIN - Name: %s" pl.name) in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LAC-PLUGIN -  Plugin loaded advertising on GA") in
          Yaks_connector.Global.Actual.add_node_plugin sys_id Yaks_connector.default_tenant_id nodeid pl self.yaks >>= Lwt.return
        | None -> Lwt.return_unit)
     | true ->
@@ -1882,10 +1882,10 @@ let agent verbose_flag debug_flag configuration custom_uuid =
   in
   (* let cb_lac_node_configuration self nodeid (pl:FTypes.node_info) =
      MVar.read self >>= fun self ->
-     let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NODE-CONF - ##############") in
-     let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NODE-CONF - Received plugin") in
-     let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NODE-CONF - Name: %s" pl.name) in
-     let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NODE-CONF -  Plugin loaded advertising on GA") in
+     let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NODE-CONF - ##############") in
+     let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NODE-CONF - Received plugin") in
+     let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NODE-CONF - Name: %s" pl.name) in
+     let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NODE-CONF -  Plugin loaded advertising on GA") in
      Yaks_connector.Global.Actual.add_node_configuration sys_id Yaks_connector.default_tenant_id nodeid pl self.yaks >>= Lwt.return
      in *)
   let cb_lac_nodes self (ni:FTypes.node_info option) (is_remove:bool) (uuid:string option) =
@@ -1894,8 +1894,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (match ni with
        | Some ni ->
          MVar.guarded self @@ fun state ->
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NI - ##############") in
-         let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NI - Updated node info advertising of GA") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NI - ##############") in
+         let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-LAC-NI - Updated node info advertising of GA") in
          let intid = ni.uuid in
          let extid = Apero.Uuid.to_string @@ Apero.Uuid.make () in
          let ext_ni = {ni with uuid = extid } in

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -988,7 +988,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           in Lwt.return record
         ) descriptor.internal_virtual_links
       in
-      let%lwt cps = Lwt_list.map_p (fun (cp:User.Descriptors.Network.connection_point_descriptor) ->
+      (* let%lwt cps = Lwt_list.map_p (fun (cp:User.Descriptors.Network.connection_point_descriptor) ->
           let cp_uuid = Apero.Uuid.to_string (Apero.Uuid.make ()) in
           let record = Infra.Descriptors.Network.{
               status = `CREATE;
@@ -1000,8 +1000,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
               vld_ref = cp.vld_ref
             }
           in Lwt.return record
-        ) descriptor.connection_points
-      in
+         ) descriptor.connection_points
+         in *)
       (* update the FDU with correct connection to the VLs *)
       (* Pretend we already ordered the fdus *)
       let ordered_fdus = descriptor.fdus in
@@ -1529,7 +1529,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
   in
   (*  *)
   let cb_gd_net_all self (net:FTypes.virtual_network option) (is_remove:bool) (uuid:string option) =
-    let%lwt net_p = get_network_plugin self in
+    let%lwt _ = get_network_plugin self in
     match is_remove with
     | false ->
       (match net with

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -1145,6 +1145,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
 
             ) fdur.interfaces
           >>= fun _ ->
+          let%lwt _ = Fos_fim_api.FDU.start fdur.uuid state.fim_api  in
           Lwt.return fdur
         ) fdus_node_maps
       in

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -85,7 +85,7 @@ let main_loop state promise =
 
 let agent verbose_flag debug_flag configuration custom_uuid =
   let level, reporter = (match verbose_flag with
-      | true -> Apero.Result.get @@ Logs.level_of_string "debug" ,  (Logs_fmt.reporter ())
+      | true -> Apero.Result.get @@ Logs.level_of_string "info" ,  (Logs_fmt.reporter ())
       | false -> Apero.Result.get @@ Logs.level_of_string "error",  (Fos_core.get_unix_syslog_reporter ())
     )
   in

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -344,6 +344,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     let interface = Apero.Option.get @@ Apero.Properties.get "interface" props in
     try%lwt
 
+
       let%lwt nodeid = Yaks_connector.Global.Actual.get_fdu_instance_node sys_id Yaks_connector.default_tenant_id instance_id state.yaks in
       let nodeid =
         match nodeid with
@@ -351,7 +352,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
         | None ->  raise @@ FException (`InternalError (`Msg ("Unable to find nodeid for this instance id" ) ))
       in
 
-      let%lwt record = Yaks_connector.Global.Actual.get_node_fdu_info sys_id Yaks_connector.default_tenant_id (Apero.Option.get state.configuration.agent.uuid) nodeid instance_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
+      let%lwt record = Yaks_connector.Global.Actual.get_node_fdu_info sys_id Yaks_connector.default_tenant_id (Apero.Option.get state.configuration.agent.uuid) "*" instance_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
       (* Find Correct Plugin *)
       let fdu_type = Fos_im.string_of_hv_type record.hypervisor in
       let%lwt plugins = Yaks_connector.Local.Actual.get_node_plugins (Apero.Option.get state.configuration.agent.uuid) state.yaks in
@@ -401,13 +402,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     let instance_id = Apero.Option.get @@ Apero.Properties.get "instance_id" props in
     try%lwt
 
-      let%lwt nodeid = Yaks_connector.Global.Actual.get_fdu_instance_node sys_id Yaks_connector.default_tenant_id instance_id state.yaks in
-      let nodeid =
-        match nodeid with
-        | Some nid -> nid
-        | None ->  raise @@ FException (`InternalError (`Msg ("Unable to find nodeid for this instance id" ) ))
-      in
-      let%lwt record = Yaks_connector.Global.Actual.get_node_fdu_info sys_id Yaks_connector.default_tenant_id (Apero.Option.get state.configuration.agent.uuid) nodeid instance_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
+
+      let%lwt record = Yaks_connector.Global.Actual.get_node_fdu_info sys_id Yaks_connector.default_tenant_id (Apero.Option.get state.configuration.agent.uuid) "*" instance_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
       (* Find Correct Plugin *)
       let fdu_type = Fos_im.string_of_hv_type record.hypervisor in
       let%lwt plugins = Yaks_connector.Local.Actual.get_node_plugins (Apero.Option.get state.configuration.agent.uuid) state.yaks in

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -674,9 +674,10 @@ let agent verbose_flag debug_flag configuration custom_uuid =
             }
           in
           Fos_fim_api.Network.add_network net_desc state.fim_api
-          >>= fun _ ->
-          (* This has to be removed! *)
-          Lwt.return @@ Unix.sleep 3
+          (* >>= fun _ ->
+             (* This has to be removed! *)
+             Lwt.return @@ Unix.sleep 3 *)
+          >>= fun _ -> Lwt.return_unit
         ) nets
       in
       let%lwt aes = Yaks_connector.Global.Actual.get_catalog_all_atomic_entities sys_id Yaks_connector.default_tenant_id state.yaks  >>=
@@ -689,8 +690,12 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       let%lwt ae_instances = Lwt_list.map_p (fun (e:string) ->
           match List.find_opt (fun x -> (String.compare x e)==0) aes with
           | Some ae_uuid ->
-            let%lwt ae_rec = Fos_faem_api.AtomicEntity.instantiate ae_uuid state.faem_api in
-            Lwt.return ae_rec.uuid
+            let%lwt desc = Yaks_connector.Global.Actual.get_catalog_atomic_entity_info sys_id Yaks_connector.default_tenant_id ae_uuid state.yaks in
+            (match desc with
+             | Some _ ->
+               let%lwt ae_rec = Fos_faem_api.AtomicEntity.instantiate ae_uuid state.faem_api in
+               Lwt.return ae_rec.uuid
+             | None -> Lwt.fail @@ FException (`NotFound (`MsgCode ((Printf.sprintf ("Atomic Entity %s not in catalog")e),404))))
           | None -> Lwt.fail @@ FException (`NotFound (`MsgCode ((Printf.sprintf ("Atomic Entity %s not in catalog")e),404)))
         ) descriptor.atomic_entities
       in
@@ -855,9 +860,10 @@ let agent verbose_flag debug_flag configuration custom_uuid =
             }
           in
           Fos_fim_api.Network.add_network net_desc state.fim_api
-          >>= fun _ ->
-          (* This has to be removed! *)
-          Lwt.return @@ Unix.sleep 3
+          (* >>= fun _ ->
+             (* This has to be removed! *)
+             Lwt.return @@ Unix.sleep 3 *)
+          >>= fun _ -> Lwt.return_unit
         ) nets
       >>= fun _ ->
       (* Onboard and Instantiate FDUs descriptors *)

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -709,7 +709,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
 
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-ENTITY - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error = Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -1532,7 +1532,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
   in
   (*  *)
   let cb_gd_net_all self (net:FTypes.virtual_network option) (is_remove:bool) (uuid:string option) =
-    let%lwt _ = get_network_plugin self in
+    let%lwt net_p = get_network_plugin self in
     match is_remove with
     | false ->
       (match net with
@@ -1550,9 +1550,9 @@ let agent verbose_flag debug_flag configuration custom_uuid =
        | Some netid -> MVar.read self >>= fun self ->
          let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - ##############") in
          let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET Removed!") in
-         (* let%lwt net_info = Yaks_connector.Local.Actual.get_node_network (Apero.Option.get self.configuration.agent.uuid) net_p netid self.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in *)
-         (* let net_info = {net_info with status = `DESTROY} in *)
-         (* let%lwt _ = Yaks_connector.Local.Desired.add_node_network (Apero.Option.get self.configuration.agent.uuid) net_p netid net_info self.yaks in *)
+         let%lwt net_info = Yaks_connector.Local.Actual.get_node_network (Apero.Option.get self.configuration.agent.uuid) net_p netid self.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
+         let net_info = {net_info with status = `DESTROY} in
+         let%lwt _ = Yaks_connector.Local.Desired.add_node_network (Apero.Option.get self.configuration.agent.uuid) net_p netid net_info self.yaks in
          Yaks_connector.Global.Actual.remove_network sys_id Yaks_connector.default_tenant_id netid self.yaks >>= Lwt.return
        | None ->
          let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET NO UUID!!!!") in

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -1116,9 +1116,9 @@ let agent verbose_flag debug_flag configuration custom_uuid =
                    let%lwt cpr = Fos_fim_api.Network.add_connection_point_to_node ae_ecp n state.fim_api in
                    Fos_fim_api.FDU.connect_interface_to_cp cpr.uuid fdur.uuid iface.name n state.fim_api
                    >>= fun _ -> Lwt.return_unit
-                 | None -> Lwt.return_unit
+                 | None ->Lwt.fail @@ FException (`NotFound (`MsgCode (( Printf.sprintf ("Unable to find Atomic entity connection point %s") ecp ),404) ))
                 )
-              | _, Some icp ->
+              | None, Some icp ->
                 (match List.find_opt (fun (e:Infra.Descriptors.FDU.connection_point_record) -> (String.compare icp e.cp_id)==0) fdur.connection_points with
                  | Some fdu_icp ->
                    (match fdu_icp.vld_ref with
@@ -1130,16 +1130,16 @@ let agent verbose_flag debug_flag configuration custom_uuid =
                              let%lwt vnet_r = Fos_fim_api.Network.add_network_to_node net_desc n state.fim_api in
                              Fos_fim_api.Network.connect_cp_to_network fdu_icp.uuid vnet_r.uuid n state.fim_api
                              >>= fun _ -> Lwt.return_unit
-                           | None -> Lwt.return_unit
+                           | None -> Lwt.fail @@ FException (`NotFound (`MsgCode (( Printf.sprintf ("Unable to find virtual network %s") vl.uuid ),404) ))
                          )
-                       | None -> Lwt.return_unit
+                       | None -> Lwt.fail @@ FException (`NotFound (`MsgCode (( Printf.sprintf ("Unable to find virtual link %s") vlr ),404) ))
                       )
                     | None -> Lwt.return_unit
                    )
                  (* Fos_fim_api.Network.add_network_to_node
                     Fos_fim_api.FDU.connect_interface_to_cp cpr.uuid fdur.uuid iface.name n state.fim_api
                     >>= fun _ -> Lwt.return_unit *)
-                 | None -> Lwt.return_unit
+                 | None -> Lwt.fail @@ FException (`NotFound (`MsgCode (( Printf.sprintf ("Unable to find FDU connection point %s") icp ),404) ))
                 )
               | _, _ ->  Lwt.return_unit
 

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -530,16 +530,13 @@ let agent verbose_flag debug_flag configuration custom_uuid =
        * Fix references with UUIDs
       *)
       let instanceid = Apero.Uuid.to_string @@ Apero.Uuid.make () in
-      let%lwt cp_records = Lwt_list.map_p (
+      let cp_records = List.map (
           fun (e:User.Descriptors.Network.connection_point_descriptor) ->
             let cpuuid = Apero.Uuid.to_string @@ Apero.Uuid.make () in
-            let r = Infra.Descriptors.Network.{  uuid = cpuuid; status = `CREATE; cp_id = e.id;
-                                                 cp_type = e.cp_type; port_security_enabled = e.port_security_enabled;
-                                                 properties = None; veth_face_name = None; br_name = None; vld_ref = e.vld_ref
-                                              }
-            in
-            let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - CP RECORD: %s" (Infra.Descriptors.Network.string_of_connection_point_record r))
-            in Lwt.return r
+            Infra.Descriptors.Network.{  uuid = cpuuid; status = `CREATE; cp_id = e.id;
+                                         cp_type = e.cp_type; port_security_enabled = e.port_security_enabled;
+                                         properties = None; veth_face_name = None; br_name = None; vld_ref = e.vld_ref
+                                      }
         ) descriptor.connection_points
       in
       let interface_records = List.map (fun (e:User.Descriptors.FDU.interface) ->
@@ -1110,8 +1107,6 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           let%lwt _ = Fos_fim_api.FDU.onboard fdu state.fim_api in
 
           let%lwt fdur = Fos_fim_api.FDU.define (Apero.Option.get fdu.uuid) n state.fim_api in
-
-          Unix.sleep 10;
 
           let%lwt _ = Fos_fim_api.FDU.configure fdur.uuid state.fim_api  in
           (* Connecting FDU interface to right connection points *)

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -270,7 +270,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-CREATE-NET - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
@@ -278,8 +278,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     MVar.read self >>= fun state ->
     try%lwt
       let%lwt net_p = get_network_plugin self in
-      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-NET - ##############") in
-      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-NET - Properties: %s" (Apero.Properties.to_string props) ) in
+      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-NET - ##############") in
+      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-NET - Properties: %s" (Apero.Properties.to_string props) ) in
       let net_id =Apero.Option.get @@ Apero.Properties.get "net_id" props in
       let%lwt record =  Yaks_connector.Local.Actual.get_node_network  (Apero.Option.get state.configuration.agent.uuid) net_p net_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
       Yaks_connector.Global.Actual.remove_network sys_id Yaks_connector.default_tenant_id record.uuid state.yaks >>= Lwt.return
@@ -289,7 +289,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
     | exn ->
-      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -118,7 +118,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
   let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - Plugin Directory: %s" plugin_path) in
   let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - AUTOLOAD: %b" conf.plugins.autoload) in
   let _ = Logs.debug (fun m -> m "[FOS-AGENT] - INIT - Plugins:") in
-  List.iter (fun p -> ignore @@ Logs_lwt.debug (fun m -> m "[FOS-AGENT] - INIT - %s" p )) (Apero.Option.get_or_default conf.plugins.auto []);
+  List.iter (fun p -> ignore @@ Logs.debug (fun m -> m "[FOS-AGENT] - INIT - %s" p )) (Apero.Option.get_or_default conf.plugins.auto []);
   (* let sys_info = system_info sys_id uuid in *)
   let%lwt yaks = Yaks_connector.get_connector conf in
   let%lwt fim = Fos_fim_api.FIMAPI.connect ~locator:(Apero.Option.get (Apero_net.Locator.of_string conf.agent.yaks)) () in
@@ -358,7 +358,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       let pl =
         match matching_plugins with
         | [] ->
-          ignore @@  Logs_lwt.err (fun m -> m "Cannot find a plugin for this FDU even if it is present in the node WTF!! %s" instance_id );
+          ignore @@  Logs.err (fun m -> m "Cannot find a plugin for this FDU even if it is present in the node WTF!! %s" instance_id );
           None
         | _ -> Some  ((List.hd matching_plugins).uuid)
       in
@@ -407,7 +407,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       let pl =
         match matching_plugins with
         | [] ->
-          ignore @@  Logs_lwt.err (fun m -> m "Cannot find a plugin for this FDU even if it is present in the node WTF!! %s" instance_id );
+          ignore @@  Logs.err (fun m -> m "Cannot find a plugin for this FDU even if it is present in the node WTF!! %s" instance_id );
           None
         | _ -> Some  ((List.hd matching_plugins).uuid)
       in
@@ -549,14 +549,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           in
           match e.virtual_interface.intf_type with
           | `PHYSICAL | `BRIDGED ->
-            let _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - THIS FDU HAS PHYSICAL INTERFACE!!!!!!!!!!!!") in
+            let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - THIS FDU HAS PHYSICAL INTERFACE!!!!!!!!!!!!") in
             let  r = Infra.Descriptors.FDU.{name = e.name; is_mgmt = e.is_mgmt; if_type = e.if_type;
                                             mac_address = e.mac_address; virtual_interface = e.virtual_interface;
                                             cp_id = cp_new_id; ext_cp_id = e.ext_cp_id;
                                             vintf_name = e.name; status = `CREATE; phy_face = Some e.virtual_interface.vpci;
                                             veth_face_name = None; properties = None}
             in
-            let _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - THIS FDU HAS PHYSICAL INTERFACE RECORD: %s" (Infra.Descriptors.FDU.string_of_interface r) ) in
+            let _ = Logs.debug (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - THIS FDU HAS PHYSICAL INTERFACE RECORD: %s" (Infra.Descriptors.FDU.string_of_interface r) ) in
             r
           | _ ->
             Infra.Descriptors.FDU.{name = e.name; is_mgmt = e.is_mgmt; if_type = e.if_type;
@@ -1469,7 +1469,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
          let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-IMAGE - Image Updated! Advertising on GA") in
          (match img.uuid with
           | Some id -> Yaks_connector.Global.Actual.add_image sys_id Yaks_connector.default_tenant_id id img self.yaks >>= Lwt.return
-          | None -> Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-IMAGE - Ignoring Image as UUID is missing!!") >>= Lwt.return)
+          | None -> Lwt.return @@ Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-IMAGE - Ignoring Image as UUID is missing!!") >>= Lwt.return)
        | None -> Lwt.return_unit)
     | true ->
       (match uuid with
@@ -1488,7 +1488,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
          let _ = Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-FLAVOR - Flavor Updated! Advertising on GA") in
          (match flv.uuid with
           | Some id -> Yaks_connector.Global.Actual.add_flavor sys_id Yaks_connector.default_tenant_id id flv self.yaks >>= Lwt.return
-          | None -> Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-FLAVOR - Ignoring Flavor as UUID is missing!!") >>= Lwt.return)
+          | None -> Lwt.return @@ Logs.debug (fun m -> m "[FOS-AGENT] - CB-GD-FLAVOR - Ignoring Flavor as UUID is missing!!") >>= Lwt.return)
        | None -> Lwt.return_unit
       )
     | true ->

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -989,6 +989,12 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           in Lwt.return record
         ) descriptor.internal_virtual_links
       in
+      let cps = List.map (fun  (cp:User.Descriptors.Network.connection_point_descriptor) ->
+          let cp_uuid = Apero.Uuid.to_string (Apero.Uuid.make ()) in
+          {cp with uuid = Some cp_uuid}
+        ) descriptor.connection_points
+      in
+      let descriptor = {descriptor with connection_points = cps} in
       (* let%lwt cps = Lwt_list.map_p (fun (cp:User.Descriptors.Network.connection_point_descriptor) ->
           let cp_uuid = Apero.Uuid.to_string (Apero.Uuid.make ()) in
           let record = Infra.Descriptors.Network.{
@@ -1114,7 +1120,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           let%lwt cprs  = Lwt_list.filter_map_s (fun (iface:Infra.Descriptors.FDU.interface) ->
               match iface.ext_cp_id, iface.cp_id with
               | Some ecp, None ->
-                (match List.find_opt (fun (e:User.Descriptors.AtomicEntity.connection_point_descriptor) -> (String.compare ecp e.id)==0) descriptor.connection_points with
+                (match List.find_opt (fun (e:User.Descriptors.Network.connection_point_descriptor) -> (String.compare ecp e.id)==0) descriptor.connection_points with
                  | Some ae_ecp ->
                    let%lwt cpr = Fos_fim_api.Network.add_connection_point_to_node ae_ecp n state.fim_api in
                    let%lwt _ = Logs_lwt.info (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-AE - CONNECTING A INTERFACE TO AN EXTERNAL CP : %s <-> %s:%s" cpr.uuid fdur.uuid iface.name ) in

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -1117,6 +1117,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
                 (match List.find_opt (fun (e:User.Descriptors.AtomicEntity.connection_point_descriptor) -> (String.compare ecp e.id)==0) descriptor.connection_points with
                  | Some ae_ecp ->
                    let%lwt cpr = Fos_fim_api.Network.add_connection_point_to_node ae_ecp n state.fim_api in
+                   let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-AE - CONNECTING A INTERFACE TO AN EXTERNAL CP : %s <-> %s:%s" cpr.uuid fdur.uuid iface.name ) in
                    Fos_fim_api.FDU.connect_interface_to_cp cpr.uuid fdur.uuid iface.name n state.fim_api
                    >>= fun _ -> Lwt.return (Some cpr)
                  | None ->Lwt.fail @@ FException (`NotFound (`MsgCode (( Printf.sprintf ("Unable to find Atomic entity connection point %s") ecp ),404) ))

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -1117,7 +1117,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
                 (match List.find_opt (fun (e:User.Descriptors.AtomicEntity.connection_point_descriptor) -> (String.compare ecp e.id)==0) descriptor.connection_points with
                  | Some ae_ecp ->
                    let%lwt cpr = Fos_fim_api.Network.add_connection_point_to_node ae_ecp n state.fim_api in
-                   let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-AE - CONNECTING A INTERFACE TO AN EXTERNAL CP : %s <-> %s:%s" cpr.uuid fdur.uuid iface.name ) in
+                   let%lwt _ = Logs_lwt.info (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-AE - CONNECTING A INTERFACE TO AN EXTERNAL CP : %s <-> %s:%s" cpr.uuid fdur.uuid iface.name ) in
                    Fos_fim_api.FDU.connect_interface_to_cp cpr.uuid fdur.uuid iface.name n state.fim_api
                    >>= fun _ -> Lwt.return (Some cpr)
                  | None ->Lwt.fail @@ FException (`NotFound (`MsgCode (( Printf.sprintf ("Unable to find Atomic entity connection point %s") ecp ),404) ))

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -683,13 +683,13 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       let%lwt aes = Yaks_connector.Global.Actual.get_catalog_all_atomic_entities sys_id Yaks_connector.default_tenant_id state.yaks  >>=
         Lwt_list.map_p (fun (e:string) ->
             let%lwt e = Yaks_connector.Global.Actual.get_catalog_atomic_entity_info sys_id Yaks_connector.default_tenant_id e state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
-            Lwt.return e.id
+            Lwt.return (e.id, Apero.Option.get e.uuid)
           )
       in
 
       let%lwt ae_instances = Lwt_list.map_p (fun (e:string) ->
-          match List.find_opt (fun x -> (String.compare x e)==0) aes with
-          | Some ae_uuid ->
+          match List.find_opt (fun (x,_) -> (String.compare x e)==0) aes with
+          | Some (_,ae_uuid) ->
             let%lwt desc = Yaks_connector.Global.Actual.get_catalog_atomic_entity_info sys_id Yaks_connector.default_tenant_id ae_uuid state.yaks in
             (match desc with
              | Some _ ->

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -1193,7 +1193,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
 
     with
     | exn ->
-      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-INSTANTIATE-AE - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error = Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
@@ -1224,7 +1224,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
 
     with
     | exn ->
-      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-TERMINATE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-TERMINATE-AE - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error = Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -628,7 +628,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           let net_uuid = Apero.Uuid.to_string (Apero.Uuid.make ()) in
           let record = Infra.Descriptors.Entity.{
               uuid = net_uuid;
-              internal_vl_id = ivl.id;
+              vl_id = ivl.id;
               is_mgmt = ivl.is_mgmt;
               vl_type = ivl.vl_type;
               root_bandwidth = ivl.root_bandwidth;
@@ -662,7 +662,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           in
           let net_desc = FTypes.{
               uuid = vl.uuid;
-              name = vl.internal_vl_id;
+              name = vl.vl_id;
               net_type = FTypes.vn_type_of_string (Infra.Descriptors.Entity.string_of_vl_kind (Apero.Option.get_or_default vl.vl_type `ELAN));
               is_mgmt = vl.is_mgmt;
               overlay = vl.overlay;

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -203,7 +203,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - eval_get_port_info - Getting info for port %s" cp_uuid ) in
     try%lwt
       let%lwt descriptor = Yaks_connector.Global.Actual.get_port sys_id Yaks_connector.default_tenant_id cp_uuid state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
-      let js = FAgentTypes.json_of_string @@ User.Descriptors.FDU.string_of_connection_point_descriptor  descriptor in
+      let js = FAgentTypes.json_of_string @@ User.Descriptors.Network.string_of_connection_point_descriptor  descriptor in
       let eval_res = FAgentTypes.{result = Some js ; error = None; error_msg = None} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
     with
@@ -212,7 +212,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       let%lwt fdu_ids = Yaks_connector.Global.Actual.get_catalog_all_fdus sys_id Yaks_connector.default_tenant_id state.yaks in
       let%lwt cps = Lwt_list.filter_map_p (fun e ->
           let%lwt fdu =  Yaks_connector.Global.Actual.get_catalog_fdu_info sys_id Yaks_connector.default_tenant_id e state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
-          let%lwt c = Lwt_list.filter_map_p (fun (cp:User.Descriptors.FDU.connection_point_descriptor) ->
+          let%lwt c = Lwt_list.filter_map_p (fun (cp:User.Descriptors.Network.connection_point_descriptor) ->
               let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - eval_get_port_info - %s == %s ? %d " cp.id cp_uuid (String.compare cp.id  cp_uuid)) in
               if (String.compare cp.id cp_uuid) == 0 then  Lwt.return @@ Some cp
               else Lwt.return None
@@ -222,7 +222,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       in
       try%lwt
         let cp = List.hd cps in
-        let js = FAgentTypes.json_of_string @@ User.Descriptors.FDU.string_of_connection_point_descriptor cp in
+        let js = FAgentTypes.json_of_string @@ User.Descriptors.Network.string_of_connection_point_descriptor cp in
         let eval_res = FAgentTypes.{result = Some js ; error = None; error_msg = None} in
         Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
       with
@@ -255,6 +255,184 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
   (* NM Evals *)
+  let eval_create_net self (props:Apero.properties) =
+    MVar.read self >>= fun state ->
+    try%lwt
+      let%lwt net_p = get_network_plugin self in
+      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-NET - ##############") in
+      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-NET - Properties: %s" (Apero.Properties.to_string props) ) in
+      let descriptor = FTypes.virtual_network_of_string @@ Apero.Option.get @@ Apero.Properties.get "descriptor" props in
+      let record = FTypesRecord.{uuid = descriptor.uuid; status = `CREATE; properties = None; ip_configuration = descriptor.ip_configuration; overlay = None; vni = None; mcast_addr = None; vlan_id = None; face = None} in
+      Yaks_connector.Local.Desired.add_node_network (Apero.Option.get state.configuration.agent.uuid) net_p descriptor.uuid record state.yaks
+      >>= fun _ ->
+      let js = JSON.of_string @@ FTypesRecord.string_of_virtual_network record in
+      let eval_res = FAgentTypes.{result = Some js ; error=None; error_msg = None} in
+      Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
+    with
+    | exn ->
+      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
+      Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
+  in
+  let eval_remove_net self (props:Apero.properties) =
+    MVar.read self >>= fun state ->
+    try%lwt
+      let%lwt net_p = get_network_plugin self in
+      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-NET - ##############") in
+      let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-NET - Properties: %s" (Apero.Properties.to_string props) ) in
+      let net_id =Apero.Option.get @@ Apero.Properties.get "net_id" props in
+      let%lwt record =  Yaks_connector.Local.Actual.get_node_network  (Apero.Option.get state.configuration.agent.uuid) net_p net_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
+      Yaks_connector.Global.Actual.remove_network sys_id Yaks_connector.default_tenant_id record.uuid state.yaks >>= Lwt.return
+      >>= fun _ ->
+      let js = JSON.of_string @@ FTypesRecord.string_of_virtual_network record in
+      let eval_res = FAgentTypes.{result = Some js ; error=None; error_msg = None} in
+      Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
+    with
+    | exn ->
+      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
+      Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
+  in
+  let eval_create_cp self (props:Apero.properties) =
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - ##############") in
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - Properties: %s" (Apero.Properties.to_string props) ) in
+    MVar.read self >>= fun state ->
+    let%lwt net_p = get_network_plugin self in
+    let descriptor = User.Descriptors.Network.connection_point_descriptor_of_string @@ Apero.Option.get @@ Apero.Properties.get "descriptor" props in
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - # NetManager: %s" net_p) in
+    try%lwt
+      let parameters = [("descriptor",User.Descriptors.Network.string_of_connection_point_descriptor descriptor)] in
+      let fname = "create_port_agent" in
+      Yaks_connector.Local.Actual.exec_nm_eval (Apero.Option.get state.configuration.agent.uuid) net_p fname parameters state.yaks
+      >>= fun res ->
+      match res with
+      | Some r -> Lwt.return @@ FAgentTypes.string_of_eval_result r
+      | None ->  Lwt.fail @@ FException (`InternalError (`MsgCode ((Printf.sprintf ("Cannot connect create cp %s") descriptor.id ),503)))
+    with
+    | exn ->
+      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-CREATE-CP - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
+      Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
+  in
+  let eval_remove_cp self (props:Apero.properties) =
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - ##############") in
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - Properties: %s" (Apero.Properties.to_string props) ) in
+    MVar.read self >>= fun state ->
+    let%lwt net_p = get_network_plugin self in
+    let cp_id =  Apero.Option.get @@ Apero.Properties.get "cp_id" props in
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - # NetManager: %s" net_p) in
+    try%lwt
+      let parameters = [("cp_id", cp_id)] in
+      let fname = "destroy_port_agent" in
+      Yaks_connector.Local.Actual.exec_nm_eval (Apero.Option.get state.configuration.agent.uuid) net_p fname parameters state.yaks
+      >>= fun res ->
+      match res with
+      | Some r -> Lwt.return @@ FAgentTypes.string_of_eval_result r
+      | None ->  Lwt.fail @@ FException (`InternalError (`MsgCode ((Printf.sprintf ("Cannot destroy create cp %s") cp_id ),503)))
+    with
+    | exn ->
+      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-REMOVE-CP - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
+      Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
+  in
+  let eval_connect_cp_to_fdu_face self (props:Apero.properties) =
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP-TO-FDU - ##############") in
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP-TO-FDU - Properties: %s" (Apero.Properties.to_string props) ) in
+    MVar.read self >>= fun state ->
+    let cp_id = Apero.Option.get @@ Apero.Properties.get "cp_id" props in
+    let instance_id = Apero.Option.get @@ Apero.Properties.get "instance_id" props in
+    let interface = Apero.Option.get @@ Apero.Properties.get "interface" props in
+    try%lwt
+      let%lwt record = Yaks_connector.Global.Actual.get_node_fdu_info sys_id Yaks_connector.default_tenant_id (Apero.Option.get state.configuration.agent.uuid) "*" instance_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
+      (* Find Correct Plugin *)
+      let fdu_type = Fos_im.string_of_hv_type record.hypervisor in
+      let%lwt plugins = Yaks_connector.Local.Actual.get_node_plugins (Apero.Option.get state.configuration.agent.uuid) state.yaks in
+      let%lwt matching_plugins = Lwt_list.filter_map_p (fun e ->
+          let%lwt pl = Yaks_connector.Local.Actual.get_node_plugin (Apero.Option.get state.configuration.agent.uuid) e state.yaks in
+          if String.uppercase_ascii (pl.name) = String.uppercase_ascii (fdu_type) then
+            Lwt.return @@ Some pl
+          else
+            Lwt.return None
+        ) plugins
+      in
+      let pl =
+        match matching_plugins with
+        | [] ->
+          ignore @@  Logs_lwt.err (fun m -> m "Cannot find a plugin for this FDU even if it is present in the node WTF!! %s" instance_id );
+          None
+        | _ -> Some  ((List.hd matching_plugins).uuid)
+      in
+      (* Create Record
+       * Add UUID for each component
+       * Fix references with UUIDs
+      *)
+      (match pl with
+       | Some plid ->
+
+         let parameters = [("cpid", cp_id);("instanceid", instance_id);("iface",interface)] in
+         let fname = "connect_interface_to_cp" in
+         Yaks_connector.Local.Actual.exec_plugin_eval (Apero.Option.get state.configuration.agent.uuid) plid fname parameters state.yaks
+         >>= fun res ->
+         (match res with
+          | Some r -> Lwt.return @@ FAgentTypes.string_of_eval_result r
+          | None ->  Lwt.fail @@ FException (`InternalError (`MsgCode ((Printf.sprintf ("Cannot connect cp to interface %s") cp_id ),503)))
+         )
+       | None ->
+         Lwt.fail @@ FException (`PluginNotFound (`MsgCode ((Printf.sprintf ("CRITICAL!!!! Cannot find a plugin for this FDU even if it is present in the node WTF!! %s") instance_id ),404))))
+    with
+    | exn ->
+      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
+      Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
+  in
+  let eval_disconnect_cp_from_fdu_face self (props:Apero.properties) =
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP-TO-FDU - ##############") in
+    let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DISCONNECT-CP-TO-FDU - Properties: %s" (Apero.Properties.to_string props) ) in
+    MVar.read self >>= fun state ->
+    let face = Apero.Option.get @@ Apero.Properties.get "interface" props in
+    let instance_id = Apero.Option.get @@ Apero.Properties.get "instance_id" props in
+    try%lwt
+      let%lwt record = Yaks_connector.Global.Actual.get_node_fdu_info sys_id Yaks_connector.default_tenant_id (Apero.Option.get state.configuration.agent.uuid) "*" instance_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
+      (* Find Correct Plugin *)
+      let fdu_type = Fos_im.string_of_hv_type record.hypervisor in
+      let%lwt plugins = Yaks_connector.Local.Actual.get_node_plugins (Apero.Option.get state.configuration.agent.uuid) state.yaks in
+      let%lwt matching_plugins = Lwt_list.filter_map_p (fun e ->
+          let%lwt pl = Yaks_connector.Local.Actual.get_node_plugin (Apero.Option.get state.configuration.agent.uuid) e state.yaks in
+          if String.uppercase_ascii (pl.name) = String.uppercase_ascii (fdu_type) then
+            Lwt.return @@ Some pl
+          else
+            Lwt.return None
+        ) plugins
+      in
+      let pl =
+        match matching_plugins with
+        | [] ->
+          ignore @@  Logs_lwt.err (fun m -> m "Cannot find a plugin for this FDU even if it is present in the node WTF!! %s" instance_id );
+          None
+        | _ -> Some  ((List.hd matching_plugins).uuid)
+      in
+      (* Create Record
+       * Add UUID for each component
+       * Fix references with UUIDs
+      *)
+      (match pl with
+       | Some plid ->
+         let parameters = [("iface", face);("instanceid", instance_id)] in
+         let fname = "disconnect_interface_from_cp" in
+         Yaks_connector.Local.Actual.exec_plugin_eval (Apero.Option.get state.configuration.agent.uuid) plid fname parameters state.yaks
+         >>= fun res ->
+         (match res with
+          | Some r -> Lwt.return @@ FAgentTypes.string_of_eval_result r
+          | None ->  Lwt.fail @@ FException (`InternalError (`MsgCode ((Printf.sprintf ("Cannot disconnect cp from interface %s") face ),503)))
+         )
+       | None ->
+         Lwt.fail @@ FException (`PluginNotFound (`MsgCode ((Printf.sprintf ("CRITICAL!!!! Cannot find a plugin for this FDU even if it is present in the node WTF!! %s") instance_id ),404))))
+    with
+    | exn ->
+      let%lwt _ = Logs_lwt.err (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let eval_res = FAgentTypes.{result = None ; error=Some 11; error_msg = Some (Printexc.to_string exn)} in
+      Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
+  in
   let eval_connect_cp_to_network self (props:Apero.properties) =
     let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP - ##############") in
     let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-CONNECT-CP - Properties: %s" (Apero.Properties.to_string props) ) in
@@ -353,13 +531,12 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       *)
       let instanceid = Apero.Uuid.to_string @@ Apero.Uuid.make () in
       let cp_records = List.map (
-          fun (e:User.Descriptors.FDU.connection_point_descriptor) ->
+          fun (e:User.Descriptors.Network.connection_point_descriptor) ->
             let cpuuid = Apero.Uuid.to_string @@ Apero.Uuid.make () in
-            Infra.Descriptors.FDU.{  uuid = cpuuid; status = `CREATE; cp_id = e.id;
-                                     cp_type = e.cp_type; port_security_enabled = e.port_security_enabled;
-                                     internal_vld_ref = e.internal_vld_ref; properties = None;
-                                     veth_face_name = None; br_name = None;
-                                  }
+            Infra.Descriptors.Network.{  uuid = cpuuid; status = `CREATE; cp_id = e.id;
+                                         cp_type = e.cp_type; port_security_enabled = e.port_security_enabled;
+                                         properties = None; veth_face_name = None; br_name = None; vld_ref = e.vld_ref
+                                      }
         ) descriptor.connection_points
       in
       let interface_records = List.map (fun (e:User.Descriptors.FDU.interface) ->
@@ -533,10 +710,10 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           )
       in
       let%lwt _ = Lwt_list.iter_p (
-          fun (e:string) ->
-            match List.find_opt (fun x -> (String.compare x e)==0) aes with
+          fun (e:User.Descriptors.Entity.constituent_atomic_entity) ->
+            match List.find_opt (fun x -> (String.compare x e.id)==0) aes with
             | Some _ -> Lwt.return_unit
-            | None -> Lwt.fail @@ FException (`NotFound (`MsgCode ((Printf.sprintf ("Atomic Entity %s not in catalog")e),404)))
+            | None -> Lwt.fail @@ FException (`NotFound (`MsgCode ((Printf.sprintf ("Atomic Entity %s not in catalog")e.id),404)))
         ) descriptor.atomic_entities
       in
       (*  *)
@@ -638,6 +815,19 @@ let agent verbose_flag debug_flag configuration custom_uuid =
       (* Add UUID to VLs *)
       let%lwt nets = Lwt_list.map_p (fun (ivl:User.Descriptors.Entity.virtual_link_descriptor) ->
           let net_uuid = Apero.Uuid.to_string (Apero.Uuid.make ()) in
+          let%lwt cps = Lwt_list.map_p (fun (e:User.Descriptors.Entity.cp_ref) ->
+              let r =
+                Infra.Descriptors.Entity.{
+                  component_id_ref = e.component_id_ref;
+                  component_index_ref = e.component_index_ref;
+                  cp_id = e.cp_id;
+                  has_floating_ip = e.has_floating_ip;
+                  uuid = Apero.Uuid.to_string @@ Apero.Uuid.make ();
+                  floating_ip_id = None;floating_ip = None;
+                }
+              in Lwt.return r
+            ) ivl.cps
+          in
           let record = Infra.Descriptors.Entity.{
               uuid = net_uuid;
               vl_id = ivl.id;
@@ -645,7 +835,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
               vl_type = ivl.vl_type;
               root_bandwidth = ivl.root_bandwidth;
               leaf_bandwidth = ivl.leaf_bandwidth;
-              cps = ivl.cps;
+              cps = cps;
               ip_configuration = ivl.ip_configuration;
               overlay = None;
               vni = None;
@@ -699,16 +889,20 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           )
       in
 
-      let%lwt ae_instances = Lwt_list.map_p (fun (e:string) ->
-          match List.find_opt (fun (x,_) -> (String.compare x e)==0) aes with
+      let%lwt ae_instances = Lwt_list.map_p (fun (e:User.Descriptors.Entity.constituent_atomic_entity) ->
+          match List.find_opt (fun (x,_) -> (String.compare x e.id)==0) aes with
           | Some (_,ae_uuid) ->
             let%lwt desc = Yaks_connector.Global.Actual.get_catalog_atomic_entity_info sys_id Yaks_connector.default_tenant_id ae_uuid state.yaks in
             (match desc with
              | Some _ ->
                let%lwt ae_rec = Fos_faem_api.AtomicEntity.instantiate ae_uuid state.faem_api in
-               Lwt.return ae_rec.uuid
-             | None -> Lwt.fail @@ FException (`NotFound (`MsgCode ((Printf.sprintf ("Atomic Entity %s not in catalog")e),404))))
-          | None -> Lwt.fail @@ FException (`NotFound (`MsgCode ((Printf.sprintf ("Atomic Entity %s not in catalog")e),404)))
+               Lwt.return Infra.Descriptors.Entity.{
+                   id = ae_uuid;
+                   uuid = ae_rec.uuid;
+                   index = e.index
+                 }
+             | None -> Lwt.fail @@ FException (`NotFound (`MsgCode ((Printf.sprintf ("Atomic Entity %s not in catalog")e.id),404))))
+          | None -> Lwt.fail @@ FException (`NotFound (`MsgCode ((Printf.sprintf ("Atomic Entity %s not in catalog")e.id),404)))
         ) descriptor.atomic_entities
       in
       let record = Infra.Descriptors.Entity.{
@@ -716,7 +910,6 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           entity_id = e_uuid;
           atomic_entities = ae_instances;
           virtual_links = nets;
-          connection_points = []
         }
       in
       let js = JSON.of_string (Infra.Descriptors.Entity.string_of_record record) in
@@ -739,8 +932,8 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     let e_instance_id = Apero.Option.get @@ Apero.Properties.get "instance_id" props in
     try%lwt
       let%lwt record = Yaks_connector.Global.Actual.get_records_entity_instance_info sys_id Yaks_connector.default_tenant_id "*" e_instance_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
-      let%lwt _ = Lwt_list.iter_p (fun (id:string) ->
-          Fos_faem_api.AtomicEntity.terminate id state.faem_api
+      let%lwt _ = Lwt_list.iter_p (fun (ae:Infra.Descriptors.Entity.constituent_atomic_entity) ->
+          Fos_faem_api.AtomicEntity.terminate ae.uuid state.faem_api
           >>= fun _ -> Lwt.return_unit
         ) record.atomic_entities
       in
@@ -795,29 +988,43 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           in Lwt.return record
         ) descriptor.internal_virtual_links
       in
+      let%lwt cps = Lwt_list.map_p (fun (cp:User.Descriptors.Network.connection_point_descriptor) ->
+          let cp_uuid = Apero.Uuid.to_string (Apero.Uuid.make ()) in
+          let record = Infra.Descriptors.Network.{
+              status = `CREATE;
+              uuid = cp_uuid;
+              cp_id = cp.id;
+              cp_type = cp.cp_type;
+              port_security_enabled = cp.port_security_enabled;
+              veth_face_name = None; br_name = None;  properties = None;
+              vld_ref = cp.vld_ref
+            }
+          in Lwt.return record
+        ) descriptor.connection_points
+      in
       (* update the FDU with correct connection to the VLs *)
       (* Pretend we already ordered the fdus *)
       let ordered_fdus = descriptor.fdus in
       (* We assing a UUID to the FDUs *)
       let%lwt fdus = Lwt_list.map_p (fun (fdu:User.Descriptors.FDU.descriptor) ->  Lwt.return {fdu with uuid = Some (Apero.Uuid.to_string (Apero.Uuid.make ())) }) ordered_fdus in
       (* update FDUs with correct id for VLs *)
-      let%lwt fdus = Lwt_list.map_p (fun (fdu:User.Descriptors.FDU.descriptor) ->
+      (* let%lwt fdus = Lwt_list.map_p (fun (fdu:User.Descriptors.FDU.descriptor) ->
 
-          let%lwt cps = Lwt_list.map_p (fun (cp:User.Descriptors.FDU.connection_point_descriptor) ->
+          let%lwt cps = Lwt_list.map_p (fun (cp:User.Descriptors.Network.connection_point_descriptor) ->
               let ivl = List.find_opt (fun (vl:Infra.Descriptors.AtomicEntity.internal_virtual_link_record) ->
                   match List.find_opt (fun id -> (String.compare id cp.id) == 0) vl.int_cps with
                   | Some _ -> true
                   | None -> false
                 ) nets in
               match ivl with
-              | Some vl -> Lwt.return {cp with internal_vld_ref = Some vl.uuid}
+              | Some vl -> Lwt.return {cp with vld_ref = Some vl.uuid}
               | None -> Lwt.return cp
             )fdu.connection_points
           in
           let fdu = {fdu with connection_points = cps} in
           Lwt.return fdu
-        )  fdus
-      in
+         )  fdus
+         in *)
       (* update the descriptor with ordered FDUs, FDU UUIDs, and VLs connections *)
       let descriptor = {descriptor with fdus = fdus} in
       (* Get compatible nodes for each FDU *)
@@ -843,7 +1050,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
         ) descriptor.fdus
       in
       (* Instantiating Virtual Networks *)
-      Lwt_list.iter_s (fun (vl:Infra.Descriptors.AtomicEntity.internal_virtual_link_record) ->
+      let%lwt netdescs = Lwt_list.map_p (fun (vl:Infra.Descriptors.AtomicEntity.internal_virtual_link_record) ->
           (* let cb_gd_net_all self (net:FTypes.virtual_network option) (is_remove:bool) (uuid:string option) = *)
           let ip_conf =
             match vl.ip_configuration with
@@ -861,7 +1068,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           let net_desc = FTypes.{
               uuid = vl.uuid;
               name = vl.internal_vl_id;
-              net_type = FTypes.vn_type_of_string (Infra.Descriptors.AtomicEntity.string_of_vl_kind (Apero.Option.get_or_default vl.vl_type `ELAN));
+              net_type = FTypes.vn_type_of_string (Base.Descriptors.Network.string_of_vl_kind (Apero.Option.get_or_default vl.vl_type `ELAN));
               is_mgmt = vl.is_mgmt;
               overlay = vl.overlay;
               vni = vl.vni;
@@ -875,14 +1082,69 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           (* >>= fun _ ->
              (* This has to be removed! *)
              Lwt.return @@ Unix.sleep 3 *)
-          >>= fun _ -> Lwt.return_unit
+          >>= fun _ -> Lwt.return net_desc
         ) nets
-      >>= fun _ ->
+      in
+      (* Lwt_list.iter_s (fun (cp:Infra.Descriptors.Network.connection_point_record) ->
+          let fdu_cp = User.Descriptors.Network.{
+              name = cp.cp_id;
+              id = cp.cp_id;
+              cp_type = cp.cp_type;
+              port_security_enabled = cp.port_security_enabled;
+              uuid = None;
+              short_name = None;
+              vld_ref = cp.vld_ref;
+            }
+          in
+          Fos_fim_api.Network.add_connection_point fdu_cp state.fim_api
+          >>= fun _ ->
+          Lwt.return_unit
+         ) cps
+         >>= fun _ -> *)
       (* Onboard and Instantiate FDUs descriptors *)
       let%lwt fdurs = Lwt_list.map_p ( fun ((fdu:User.Descriptors.FDU.descriptor),(nodes:string list)) ->
           let n = List.nth nodes (Random.int (List.length nodes)) in
           let%lwt _ = Fos_fim_api.FDU.onboard fdu state.fim_api in
-          let%lwt fdur = Fos_fim_api.FDU.instantiate (Apero.Option.get fdu.uuid) n state.fim_api in
+
+          let%lwt fdur = Fos_fim_api.FDU.define (Apero.Option.get fdu.uuid) n state.fim_api in
+          let%lwt _ = Fos_fim_api.FDU.configure fdur.uuid state.fim_api  in
+          Lwt_list.iter_s (fun (iface:Infra.Descriptors.FDU.interface) ->
+              match iface.ext_cp_id, iface.cp_id with
+              | Some ecp, None ->
+                (match List.find_opt (fun (e:User.Descriptors.AtomicEntity.connection_point_descriptor) -> (String.compare ecp e.id)==0) descriptor.connection_points with
+                 | Some ae_ecp ->
+                   let%lwt cpr = Fos_fim_api.Network.add_connection_point_to_node ae_ecp n state.fim_api in
+                   Fos_fim_api.FDU.connect_interface_to_cp cpr.uuid fdur.uuid iface.name n state.fim_api
+                   >>= fun _ -> Lwt.return_unit
+                 | None -> Lwt.return_unit
+                )
+              | _, Some icp ->
+                (match List.find_opt (fun (e:Infra.Descriptors.FDU.connection_point_record) -> (String.compare icp e.cp_id)==0) fdur.connection_points with
+                 | Some fdu_icp ->
+                   (match fdu_icp.vld_ref with
+                    | Some vlr ->
+                      (match List.find_opt (fun (e:Infra.Descriptors.AtomicEntity.internal_virtual_link_record) -> (String.compare e.internal_vl_id vlr)==0 ) nets with
+                       | Some vl ->
+                         ( match List.find_opt (fun (e:FTypes.virtual_network) -> (String.compare vl.uuid e.uuid)==0) netdescs with
+                           | Some net_desc ->
+                             let%lwt vnet_r = Fos_fim_api.Network.add_network_to_node net_desc n state.fim_api in
+                             Fos_fim_api.Network.connect_cp_to_network fdu_icp.uuid vnet_r.uuid n state.fim_api
+                             >>= fun _ -> Lwt.return_unit
+                           | None -> Lwt.return_unit
+                         )
+                       | None -> Lwt.return_unit
+                      )
+                    | None -> Lwt.return_unit
+                   )
+                 (* Fos_fim_api.Network.add_network_to_node
+                    Fos_fim_api.FDU.connect_interface_to_cp cpr.uuid fdur.uuid iface.name n state.fim_api
+                    >>= fun _ -> Lwt.return_unit *)
+                 | None -> Lwt.return_unit
+                )
+              | _, _ ->  Lwt.return_unit
+
+            ) fdur.interfaces
+          >>= fun _ ->
           Lwt.return fdur
         ) fdus_node_maps
       in
@@ -1276,18 +1538,18 @@ let agent verbose_flag debug_flag configuration custom_uuid =
          let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - ##############") in
          let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET Updated! Agent will update actual store and call the right plugin!") in
          let%lwt _ = Yaks_connector.Global.Actual.add_network sys_id Yaks_connector.default_tenant_id net.uuid net self.yaks in
-         let record = FTypesRecord.{uuid = net.uuid; status = `CREATE; properties = None; ip_configuration = net.ip_configuration; overlay = None; vni = None; mcast_addr = None; vlan_id = None; face = None} in
-         Yaks_connector.Local.Desired.add_node_network (Apero.Option.get self.configuration.agent.uuid) net_p net.uuid record self.yaks
-         >>= Lwt.return
+         (* let record = FTypesRecord.{uuid = net.uuid; status = `CREATE; properties = None; ip_configuration = net.ip_configuration; overlay = None; vni = None; mcast_addr = None; vlan_id = None; face = None} in *)
+         (* Yaks_connector.Local.Desired.add_node_network (Apero.Option.get self.configuration.agent.uuid) net_p net.uuid record self.yaks *)
+         Lwt.return_unit
        | None -> Lwt.return_unit)
     | true ->
       (match uuid with
        | Some netid -> MVar.read self >>= fun self ->
          let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - ##############") in
          let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET Removed!") in
-         let%lwt net_info = Yaks_connector.Local.Actual.get_node_network (Apero.Option.get self.configuration.agent.uuid) net_p netid self.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
-         let net_info = {net_info with status = `DESTROY} in
-         let%lwt _ = Yaks_connector.Local.Desired.add_node_network (Apero.Option.get self.configuration.agent.uuid) net_p netid net_info self.yaks in
+         (* let%lwt net_info = Yaks_connector.Local.Actual.get_node_network (Apero.Option.get self.configuration.agent.uuid) net_p netid self.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in *)
+         (* let net_info = {net_info with status = `DESTROY} in *)
+         (* let%lwt _ = Yaks_connector.Local.Desired.add_node_network (Apero.Option.get self.configuration.agent.uuid) net_p netid net_info self.yaks in *)
          Yaks_connector.Global.Actual.remove_network sys_id Yaks_connector.default_tenant_id netid self.yaks >>= Lwt.return
        | None ->
          let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-NET - vNET NO UUID!!!!") in
@@ -1323,7 +1585,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
          Lwt.return_unit)
 
   in
-  let cb_gd_cp self (cp:User.Descriptors.FDU.connection_point_descriptor option) (is_remove:bool) (uuid:string option) =
+  let cb_gd_cp self (cp:User.Descriptors.Network.connection_point_descriptor option) (is_remove:bool) (uuid:string option) =
     let%lwt net_p = get_network_plugin self in
     match is_remove with
     | false ->
@@ -1333,7 +1595,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-CP - ##############") in
           let%lwt _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - CB-GD-CP - CP Updated! Agent will update actual store and call the right plugin!") in
           let%lwt _ = Yaks_connector.Global.Actual.add_port sys_id Yaks_connector.default_tenant_id cp.id cp self.yaks in
-          let record = Infra.Descriptors.FDU.{cp_id = cp.id; uuid = cp.id; status = `CREATE; properties = None; veth_face_name = None; br_name = None;cp_type= Some `VPORT; port_security_enabled=None; internal_vld_ref=None } in
+          let record = Infra.Descriptors.Network.{cp_id = cp.id; uuid = cp.id; status = `CREATE; properties = None; veth_face_name = None; br_name = None;cp_type= Some `VPORT; port_security_enabled=None; vld_ref = cp.vld_ref} in
           Yaks_connector.Local.Desired.add_node_port (Apero.Option.get self.configuration.agent.uuid) net_p record.uuid record self.yaks
           >>= Lwt.return
         | None -> Lwt.return_unit)
@@ -1644,6 +1906,12 @@ let agent verbose_flag debug_flag configuration custom_uuid =
   let%lwt _ = Yaks_connector.Local.Actual.add_agent_eval uuid "get_port_info" (eval_get_port_info state) yaks in
   let%lwt _ = Yaks_connector.Local.Actual.add_agent_eval uuid "get_image_info" (eval_get_image_info state) yaks in
   (* Network Mgmt Evals *)
+  let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "create_node_network" (eval_create_net state) yaks in
+  let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "remove_node_netwotk" (eval_remove_net state) yaks in
+  let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "create_cp" (eval_create_cp state) yaks in
+  let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "remove_cp" (eval_remove_cp state) yaks in
+  let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "connect_cp_to_face" (eval_connect_cp_to_fdu_face state) yaks in
+  let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "disconnect_cp_from_face" (eval_disconnect_cp_from_fdu_face state) yaks in
   let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "add_port_to_network" (eval_connect_cp_to_network state) yaks in
   let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "remove_port_from_network" (eval_remove_cp_from_network state) yaks in
   let%lwt _ = Yaks_connector.Global.Actual.add_agent_eval sys_id Yaks_connector.default_tenant_id uuid "create_floating_ip" (eval_create_floating_ip state) yaks in
@@ -1767,6 +2035,8 @@ let info =
 let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)
 let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)
 
+let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)
+let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)
 let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)
 let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)
 let () = Cmdliner.Term.exit @@ Cmdliner.Term.eval (agent_t, info)

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -674,7 +674,9 @@ let agent verbose_flag debug_flag configuration custom_uuid =
             }
           in
           Fos_fim_api.Network.add_network net_desc state.fim_api
-          >>= fun _ -> Lwt.return_unit
+          >>= fun _ ->
+          (* This has to be removed! *)
+          Lwt.return @@ Unix.sleep 3
         ) nets
       in
       let%lwt aes = Yaks_connector.Global.Actual.get_catalog_all_atomic_entities sys_id Yaks_connector.default_tenant_id state.yaks  >>=

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -372,11 +372,15 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           in
           match e.virtual_interface.intf_type with
           | `PHYSICAL | `BRIDGED ->
-            Infra.Descriptors.FDU.{name = e.name; is_mgmt = e.is_mgmt; if_type = e.if_type;
-                                   mac_address = e.mac_address; virtual_interface = e.virtual_interface;
-                                   cp_id = cp_new_id; ext_cp_id = e.ext_cp_id;
-                                   vintf_name = e.name; status = `CREATE; phy_face = Some e.virtual_interface.vpci;
-                                   veth_face_name = None; properties = None}
+            let _ = Logs_lwt.info (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - THIS FDU HAS PHYSICAL INTERFACE!!!!!!!!!!!!") in
+            let  r = Infra.Descriptors.FDU.{name = e.name; is_mgmt = e.is_mgmt; if_type = e.if_type;
+                                            mac_address = e.mac_address; virtual_interface = e.virtual_interface;
+                                            cp_id = cp_new_id; ext_cp_id = e.ext_cp_id;
+                                            vintf_name = e.name; status = `CREATE; phy_face = Some e.virtual_interface.vpci;
+                                            veth_face_name = None; properties = None}
+            in
+            let _ = Logs_lwt.info (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - THIS FDU HAS PHYSICAL INTERFACE RECORD: %s" (Infra.Descriptors.FDU.string_of_interface r) ) in
+            r
           | _ ->
             Infra.Descriptors.FDU.{name = e.name; is_mgmt = e.is_mgmt; if_type = e.if_type;
                                    mac_address = e.mac_address; virtual_interface = e.virtual_interface;

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -552,14 +552,14 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           in
           match e.virtual_interface.intf_type with
           | `PHYSICAL | `BRIDGED ->
-            let _ = Logs_lwt.info (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - THIS FDU HAS PHYSICAL INTERFACE!!!!!!!!!!!!") in
+            let _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - THIS FDU HAS PHYSICAL INTERFACE!!!!!!!!!!!!") in
             let  r = Infra.Descriptors.FDU.{name = e.name; is_mgmt = e.is_mgmt; if_type = e.if_type;
                                             mac_address = e.mac_address; virtual_interface = e.virtual_interface;
                                             cp_id = cp_new_id; ext_cp_id = e.ext_cp_id;
                                             vintf_name = e.name; status = `CREATE; phy_face = Some e.virtual_interface.vpci;
                                             veth_face_name = None; properties = None}
             in
-            let _ = Logs_lwt.info (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - THIS FDU HAS PHYSICAL INTERFACE RECORD: %s" (Infra.Descriptors.FDU.string_of_interface r) ) in
+            let _ = Logs_lwt.debug (fun m -> m "[FOS-AGENT] - EV-DEFINE-FDU - THIS FDU HAS PHYSICAL INTERFACE RECORD: %s" (Infra.Descriptors.FDU.string_of_interface r) ) in
             r
           | _ ->
             Infra.Descriptors.FDU.{name = e.name; is_mgmt = e.is_mgmt; if_type = e.if_type;

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -345,12 +345,12 @@ let agent verbose_flag debug_flag configuration custom_uuid =
     try%lwt
 
 
-      let%lwt nodeid = Yaks_connector.Global.Actual.get_fdu_instance_node sys_id Yaks_connector.default_tenant_id instance_id state.yaks in
-      let nodeid =
-        match nodeid with
-        | Some nid -> nid
-        | None ->  raise @@ FException (`InternalError (`Msg ("Unable to find nodeid for this instance id" ) ))
-      in
+      (* let%lwt nodeid = Yaks_connector.Global.Actual.get_fdu_instance_node sys_id Yaks_connector.default_tenant_id instance_id state.yaks in
+         let nodeid =
+         match nodeid with
+         | Some nid -> nid
+         | None ->  raise @@ FException (`InternalError (`Msg ("Unable to find nodeid for this instance id" ) ))
+         in *)
 
       let%lwt record = Yaks_connector.Global.Actual.get_node_fdu_info sys_id Yaks_connector.default_tenant_id (Apero.Option.get state.configuration.agent.uuid) "*" instance_id state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in
       (* Find Correct Plugin *)

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -370,11 +370,19 @@ let agent verbose_flag debug_flag configuration custom_uuid =
               in Some cp.uuid
             | None -> None
           in
-          Infra.Descriptors.FDU.{name = e.name; is_mgmt = e.is_mgmt; if_type = e.if_type;
-                                 mac_address = e.mac_address; virtual_interface = e.virtual_interface;
-                                 cp_id = cp_new_id; ext_cp_id = e.ext_cp_id;
-                                 vintf_name = e.name; status = `CREATE; phy_face = None;
-                                 veth_face_name = None; properties = None}
+          match e.virtual_interface.intf_type with
+          | `PHYSICAL | `BRIDGED ->
+            Infra.Descriptors.FDU.{name = e.name; is_mgmt = e.is_mgmt; if_type = e.if_type;
+                                   mac_address = e.mac_address; virtual_interface = e.virtual_interface;
+                                   cp_id = cp_new_id; ext_cp_id = e.ext_cp_id;
+                                   vintf_name = e.name; status = `CREATE; phy_face = Some e.virtual_interface.vpci;
+                                   veth_face_name = None; properties = None}
+          | _ ->
+            Infra.Descriptors.FDU.{name = e.name; is_mgmt = e.is_mgmt; if_type = e.if_type;
+                                   mac_address = e.mac_address; virtual_interface = e.virtual_interface;
+                                   cp_id = cp_new_id; ext_cp_id = e.ext_cp_id;
+                                   vintf_name = e.name; status = `CREATE; phy_face = None;
+                                   veth_face_name = None; properties = None}
 
 
         ) descriptor.interfaces

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -882,6 +882,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           >>= fun _ -> Lwt.return_unit
         ) nets
       in
+      ignore netdescs;
       let%lwt aes = Yaks_connector.Global.Actual.get_catalog_all_atomic_entities sys_id Yaks_connector.default_tenant_id state.yaks  >>=
         Lwt_list.map_p (fun (e:string) ->
             let%lwt e = Yaks_connector.Global.Actual.get_catalog_atomic_entity_info sys_id Yaks_connector.default_tenant_id e state.yaks >>= fun x -> Lwt.return @@ Apero.Option.get x in

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -1014,7 +1014,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
 
     with
     | exn ->
-      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-TERMINATE-FDU - EXCEPTION: %s" (Printexc.to_string exn)) in
+      let _ = Logs.err (fun m -> m "[FOS-AGENT] - EV-TERMINATE-ENTITY - EXCEPTION: %s" (Printexc.to_string exn)) in
       let eval_res = FAgentTypes.{result = None ; error = Some 11; error_msg = Some (Printexc.to_string exn)} in
       Lwt.return @@ FAgentTypes.string_of_eval_result eval_res
   in
@@ -1265,7 +1265,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
           let%lwt cp_node = Fos_fim_api.Network.get_node_from_connection_point cp.cp_id state.fim_api in
           (match cp_node with
            |Some cp_node ->
-             let%lwt _ = Fos_fim_api.Network.remove_connection_point_from_node cp.cp_id cp_node state.fim_api in
+             let%lwt _ = Fos_fim_api.Network.remove_connection_point_from_node cp.uuid cp_node state.fim_api in
              Lwt.return_unit
            | None -> Lwt.fail @@ FException (`NotFound (`MsgCode (( Printf.sprintf ("Unable to find a node for this CP %s") cp.uuid ),404) ))
           )

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -1108,6 +1108,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
 
           let%lwt fdur = Fos_fim_api.FDU.define (Apero.Option.get fdu.uuid) n state.fim_api in
           let%lwt _ = Fos_fim_api.FDU.configure fdur.uuid state.fim_api  in
+          (* Connecting FDU interface to right connection points *)
           Lwt_list.iter_s (fun (iface:Infra.Descriptors.FDU.interface) ->
               match iface.ext_cp_id, iface.cp_id with
               | Some ecp, None ->
@@ -1119,7 +1120,7 @@ let agent verbose_flag debug_flag configuration custom_uuid =
                  | None ->Lwt.fail @@ FException (`NotFound (`MsgCode (( Printf.sprintf ("Unable to find Atomic entity connection point %s") ecp ),404) ))
                 )
               | None, Some icp ->
-                (match List.find_opt (fun (e:Infra.Descriptors.FDU.connection_point_record) -> (String.compare icp e.cp_id)==0) fdur.connection_points with
+                (match List.find_opt (fun (e:Infra.Descriptors.FDU.connection_point_record) -> (String.compare icp e.uuid)==0) fdur.connection_points with
                  | Some fdu_icp ->
                    (match fdu_icp.vld_ref with
                     | Some vlr ->

--- a/src/agent/fos-agent/fos_agent.ml
+++ b/src/agent/fos-agent/fos_agent.ml
@@ -1262,10 +1262,10 @@ let agent verbose_flag debug_flag configuration custom_uuid =
         ) record.internal_virtual_links
       in
       let%lwt _ = Lwt_list.iter_s (fun (cp:Infra.Descriptors.Network.connection_point_record) ->
-          let%lwt cp_node = Fos_fim_api.Network.get_node_from_connection_point cp.uuid state.fim_api in
+          let%lwt cp_node = Fos_fim_api.Network.get_node_from_connection_point cp.cp_id state.fim_api in
           (match cp_node with
            |Some cp_node ->
-             let%lwt _ = Fos_fim_api.Network.remove_connection_point_from_node cp.uuid cp_node state.fim_api in
+             let%lwt _ = Fos_fim_api.Network.remove_connection_point_from_node cp.cp_id cp_node state.fim_api in
              Lwt.return_unit
            | None -> Lwt.fail @@ FException (`NotFound (`MsgCode (( Printf.sprintf ("Unable to find a node for this CP %s") cp.uuid ),404) ))
           )

--- a/src/api/ocaml/faemapi/fos-faem-api/fos_faem_api.ml
+++ b/src/api/ocaml/faemapi/fos-faem-api/fos_faem_api.ml
@@ -36,38 +36,38 @@ module AtomicEntity = struct
     let%lwt nodes = Yaks_connector.Global.Actual.get_all_nodes api.sysid api.tenantid api.yconnector in
     let n = List.nth nodes (Random.int (List.length nodes)) in
     let%lwt res = Yaks_connector.Global.Actual.onboard_ae_from_node api.sysid api.tenantid n ae api.yconnector in
-    match res.result with
-    | Some js ->
+    match res.result, res.error, res.error_msg with
+    | Some js, None, None ->
       Lwt.return @@ User.Descriptors.AtomicEntity.descriptor_of_string (JSON.to_string js)
-    | None -> raise @@ FException (`InternalError (`Msg ("Error during onboarding")))
+    | None, Some id, Some msg -> raise @@ FException (`InternalError (`MsgCode (msg,id)))
+
 
   let instantiate ae_id api =
     let%lwt nodes = Yaks_connector.Global.Actual.get_all_nodes api.sysid api.tenantid api.yconnector in
     let n = List.nth nodes (Random.int (List.length nodes)) in
     let%lwt res = Yaks_connector.Global.Actual.instantiate_ae_from_node api.sysid api.tenantid n ae_id api.yconnector in
-    match res.result with
-    | Some js ->
+    match res.result, res.error, res.error_msg with
+    | Some js, None, None ->
       Lwt.return @@ Infra.Descriptors.AtomicEntity.record_of_string (JSON.to_string js)
-    | None -> raise @@ FException (`InternalError (`Msg ("Error during onboarding")))
-
+    | None, Some id, Some msg -> raise @@ FException (`InternalError (`MsgCode (msg,id)))
 
   let terminate inst_id api =
     let%lwt nodes = Yaks_connector.Global.Actual.get_all_nodes api.sysid api.tenantid api.yconnector in
     let n = List.nth nodes (Random.int (List.length nodes)) in
     let%lwt res = Yaks_connector.Global.Actual.terminate_ae_from_node api.sysid api.tenantid n inst_id api.yconnector in
-    match res.result with
-    | Some js ->
+    match res.result, res.error, res.error_msg with
+    | Some js, None, None ->
       Lwt.return @@ Infra.Descriptors.AtomicEntity.record_of_string (JSON.to_string js)
-    | None -> raise @@ FException (`InternalError (`Msg ("Error during onboarding")))
+    | None, Some id, Some msg -> raise @@ FException (`InternalError (`MsgCode (msg,id)))
 
   let offload ae_id api =
     let%lwt nodes = Yaks_connector.Global.Actual.get_all_nodes api.sysid api.tenantid api.yconnector in
     let n = List.nth nodes (Random.int (List.length nodes)) in
     let%lwt res = Yaks_connector.Global.Actual.offload_ae_from_node api.sysid api.tenantid n ae_id api.yconnector in
-    match res.result with
-    | Some js ->
+    match res.result, res.error, res.error_msg with
+    | Some js, None, None ->
       Lwt.return @@ User.Descriptors.AtomicEntity.descriptor_of_string (JSON.to_string js)
-    | None -> raise @@ FException (`InternalError (`Msg ("Error during onboarding")))
+    | None, Some id, Some msg -> raise @@ FException (`InternalError (`MsgCode (msg,id)))
 
   let get_atomic_entity_descriptor ae_id  api =
     let%lwt res  = Yaks_connector.Global.Actual.get_catalog_atomic_entity_info api.sysid api.tenantid ae_id api.yconnector in

--- a/src/api/ocaml/faemapi/fos-faem-api/fos_faem_api.mli
+++ b/src/api/ocaml/faemapi/fos-faem-api/fos_faem_api.mli
@@ -27,6 +27,9 @@ module AtomicEntity : sig
   val get_atomic_entity_descriptor : string -> faemapi -> User.Descriptors.AtomicEntity.descriptor Lwt.t
   val get_atomic_entity_instance_info : string -> faemapi -> Infra.Descriptors.AtomicEntity.record Lwt.t
 
+  val list : faemapi -> string list Lwt.t
+  val instance_list : string -> faemapi -> string list Lwt.t
+
 end
 
 

--- a/src/api/ocaml/feoapi/Makefile
+++ b/src/api/ocaml/feoapi/Makefile
@@ -1,0 +1,12 @@
+all:
+	dune build
+
+clean:
+	dune clean
+	rm -rf ./_build
+
+install:
+	opam install . --working-dir
+
+uninstall:
+	opam remove fos-feo-api

--- a/src/api/ocaml/feoapi/fos-feo-api.opam
+++ b/src/api/ocaml/feoapi/fos-feo-api.opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+version:"0.1"
+maintainer: "gabriele.baldoni@adlinktech.com"
+license: "ELP 2"
+authors:      "Gabriele Baldoni"
+homepage:     "https://github.com/eclipse/fog05"
+bug-reports:  "https://github.com/eclipse/fog05/issues/"
+dev-repo:     "https://github.com/eclipse/fog05.git"
+
+build: [
+ ["dune" "-p" name "-j" jobs]
+]
+
+install: [
+  ["dune" "build" "-p" name "@install"]
+  ["dune" "install" name]
+]
+
+depends: [
+  "dune"
+  "fos-im"
+  "fos-core"
+  "apero-core"
+]
+
+
+synopsis : "Eclipse fog05 FEO API"
+description: """
+Eclipse fog05 FEO API is a collection of OCaml libraries used to interact
+with Eclipse fog05 FEO"""

--- a/src/api/ocaml/feoapi/fos-feo-api/dune
+++ b/src/api/ocaml/feoapi/fos-feo-api/dune
@@ -1,0 +1,7 @@
+(library
+  (name            fos_feo_api)
+  (public_name     fos-feo-api)
+  (wrapped     false)
+  (libraries       fos-core fos-im yaks-common yaks-ocaml apero-core logs-syslog.unix apero-net yojson atdgen lwt logs logs.fmt logs.cli fmt fmt.cli fmt.tty)
+  (preprocess
+    (pps ppx_deriving.show ppx_deriving.ord lwt_ppx ppx_cstruct)))

--- a/src/api/ocaml/feoapi/fos-feo-api/fos_feo_api.ml
+++ b/src/api/ocaml/feoapi/fos-feo-api/fos_feo_api.ml
@@ -18,7 +18,7 @@ let ysystem = Apero.Option.get_or_default (Sys.getenv_opt "FOS_SYS_ID") "0"
 let ytenant = Apero.Option.get_or_default (Sys.getenv_opt "FOS_TENANT_ID") "0"
 
 
-type faemapi = {
+type feoapi = {
   yconnector : Yaks_connector.connector;
   sysid : string;
   tenantid: string;
@@ -30,69 +30,69 @@ type faemapi = {
 
 
 
-module AtomicEntity = struct
+module Entity = struct
 
-  let onboard (ae:User.Descriptors.AtomicEntity.descriptor) api =
+  let onboard (entity:User.Descriptors.Entity.descriptor) api =
     let%lwt nodes = Yaks_connector.Global.Actual.get_all_nodes api.sysid api.tenantid api.yconnector in
     let n = List.nth nodes (Random.int (List.length nodes)) in
-    let%lwt res = Yaks_connector.Global.Actual.onboard_ae_from_node api.sysid api.tenantid n ae api.yconnector in
+    let%lwt res = Yaks_connector.Global.Actual.onboard_entity_from_node api.sysid api.tenantid n entity api.yconnector in
     match res.result with
     | Some js ->
-      Lwt.return @@ User.Descriptors.AtomicEntity.descriptor_of_string (JSON.to_string js)
+      Lwt.return @@ User.Descriptors.Entity.descriptor_of_string (JSON.to_string js)
     | None -> raise @@ FException (`InternalError (`Msg ("Error during onboarding")))
 
-  let instantiate ae_id api =
+  let instantiate entity_id api =
     let%lwt nodes = Yaks_connector.Global.Actual.get_all_nodes api.sysid api.tenantid api.yconnector in
     let n = List.nth nodes (Random.int (List.length nodes)) in
-    let%lwt res = Yaks_connector.Global.Actual.instantiate_ae_from_node api.sysid api.tenantid n ae_id api.yconnector in
+    let%lwt res = Yaks_connector.Global.Actual.instantiate_entity_from_node api.sysid api.tenantid n entity_id api.yconnector in
     match res.result with
     | Some js ->
-      Lwt.return @@ Infra.Descriptors.AtomicEntity.record_of_string (JSON.to_string js)
+      Lwt.return @@ Infra.Descriptors.Entity.record_of_string (JSON.to_string js)
     | None -> raise @@ FException (`InternalError (`Msg ("Error during onboarding")))
 
 
   let terminate inst_id api =
     let%lwt nodes = Yaks_connector.Global.Actual.get_all_nodes api.sysid api.tenantid api.yconnector in
     let n = List.nth nodes (Random.int (List.length nodes)) in
-    let%lwt res = Yaks_connector.Global.Actual.terminate_ae_from_node api.sysid api.tenantid n inst_id api.yconnector in
+    let%lwt res = Yaks_connector.Global.Actual.terminate_entity_from_node api.sysid api.tenantid n inst_id api.yconnector in
     match res.result with
     | Some js ->
-      Lwt.return @@ Infra.Descriptors.AtomicEntity.record_of_string (JSON.to_string js)
+      Lwt.return @@ Infra.Descriptors.Entity.record_of_string (JSON.to_string js)
     | None -> raise @@ FException (`InternalError (`Msg ("Error during onboarding")))
 
-  let offload ae_id api =
+  let offload entity_id api =
     let%lwt nodes = Yaks_connector.Global.Actual.get_all_nodes api.sysid api.tenantid api.yconnector in
     let n = List.nth nodes (Random.int (List.length nodes)) in
-    let%lwt res = Yaks_connector.Global.Actual.offload_ae_from_node api.sysid api.tenantid n ae_id api.yconnector in
+    let%lwt res = Yaks_connector.Global.Actual.offload_entity_from_node api.sysid api.tenantid n entity_id api.yconnector in
     match res.result with
     | Some js ->
-      Lwt.return @@ User.Descriptors.AtomicEntity.descriptor_of_string (JSON.to_string js)
+      Lwt.return @@ User.Descriptors.Entity.descriptor_of_string (JSON.to_string js)
     | None -> raise @@ FException (`InternalError (`Msg ("Error during onboarding")))
 
-  let get_atomic_entity_descriptor ae_id  api =
-    let%lwt res  = Yaks_connector.Global.Actual.get_catalog_atomic_entity_info api.sysid api.tenantid ae_id api.yconnector in
+  let get_entity_descriptor entity_id  api =
+    let%lwt res  = Yaks_connector.Global.Actual.get_catalog_entity_info api.sysid api.tenantid entity_id api.yconnector in
     match res with
     | Some x -> Lwt.return x
     | None -> raise @@ FException (`InternalError (`Msg ("Atomic Entity not found")))
 
-  let get_atomic_entity_instance_info instance_id  api =
-    let%lwt res = Yaks_connector.Global.Actual.get_records_atomic_entity_instance_info api.sysid api.tenantid "*" instance_id api.yconnector in
+  let get_entity_instance_info instance_id  api =
+    let%lwt res = Yaks_connector.Global.Actual.get_records_entity_instance_info api.sysid api.tenantid "*" instance_id api.yconnector in
     match res with
     | Some x -> Lwt.return x
     | None -> raise @@ FException (`InternalError (`Msg ("Atomic Entity instance not found")))
 
 
   let list api =
-    Yaks_connector.Global.Actual.get_catalog_all_atomic_entities api.sysid api.tenantid api.yconnector
+    Yaks_connector.Global.Actual.get_catalog_all_entities api.sysid api.tenantid api.yconnector
 
 
-  let instance_list atomic_entity_id api =
-    Yaks_connector.Global.Actual.get_records_all_atomic_entity_instances api.sysid api.tenantid atomic_entity_id api.yconnector
+  let instance_list entity_id api =
+    Yaks_connector.Global.Actual.get_records_all_entity_instances api.sysid api.tenantid entity_id api.yconnector
 
 end
 
 
-module FAEMAPI = struct
+module FEOAPI = struct
 
   let connect ?(locator=ylocator) ?(sysid=ysystem) ?(tenantid=ytenant) () =
     let%lwt yconnector = Yaks_connector.get_connector_of_locator locator in

--- a/src/api/ocaml/feoapi/fos-feo-api/fos_feo_api.mli
+++ b/src/api/ocaml/feoapi/fos-feo-api/fos_feo_api.mli
@@ -1,0 +1,41 @@
+(*********************************************************************************
+ * Copyright (c) 2018 ADLINK Technology Inc. *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ * Contributors: 1
+ *   Gabriele Baldoni (gabriele (dot) baldoni (at) adlinktech (dot) com ) - OCaml implementation
+ *********************************************************************************)
+
+
+open Fos_im
+type feoapi
+
+
+
+
+
+module Entity : sig
+
+  val onboard : User.Descriptors.Entity.descriptor -> feoapi  -> User.Descriptors.Entity.descriptor Lwt.t
+  val instantiate : string -> feoapi -> Infra.Descriptors.Entity.record Lwt.t
+  val terminate : string -> feoapi -> Infra.Descriptors.Entity.record Lwt.t
+  val offload : string -> feoapi -> User.Descriptors.Entity.descriptor Lwt.t
+  val get_entity_descriptor : string -> feoapi -> User.Descriptors.Entity.descriptor Lwt.t
+  val get_entity_instance_info : string -> feoapi -> Infra.Descriptors.Entity.record Lwt.t
+
+  val list : feoapi -> string list Lwt.t
+  val instance_list : string -> feoapi -> string list Lwt.t
+
+end
+
+
+module FEOAPI : sig
+
+  val connect : ?locator:Apero_net.Locator.t -> ?sysid:string -> ?tenantid:string -> unit -> feoapi Lwt.t
+  val close : feoapi -> unit Lwt.t
+
+end

--- a/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.ml
+++ b/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.ml
@@ -166,7 +166,7 @@ module Network = struct
     match res.result with
     | Some js ->
       Lwt.return @@ (JSON.to_string js)
-    | None -> raise @@ FException (`InternalError (`Msg ("Error during connection point connection")))
+    | None -> raise @@ FException (`InternalError (`Msg ("Error during connection point connection to network")))
 
 
   let disconnect_cp_from_network cpid nodeid api =
@@ -174,7 +174,7 @@ module Network = struct
     match res.result with
     | Some js ->
       Lwt.return @@ (JSON.to_string js)
-    | None -> raise @@ FException (`InternalError (`Msg ("Error during connection point disconnection")))
+    | None -> raise @@ FException (`InternalError (`Msg ("Error during connection point disconnection from network")))
 
 
   let create_floating_ip nodeid api =
@@ -437,7 +437,7 @@ module FDU = struct
     match res.result with
     | Some js ->
       Lwt.return @@ (JSON.to_string js)
-    | None -> raise @@ FException (`InternalError (`Msg ("Error during connection point connection")))
+    | None -> raise @@ FException (`InternalError (`Msg ("Error during connection point connection to interface")))
 
 
   let disconnect_interface_from_cp face instanceid nodeid api =
@@ -445,7 +445,7 @@ module FDU = struct
     match res.result with
     | Some js ->
       Lwt.return @@ (JSON.to_string js)
-    | None -> raise @@ FException (`InternalError (`Msg ("Error during connection point removal")))
+    | None -> raise @@ FException (`InternalError (`Msg ("Error during connection point disconnection from interface")))
 
 
 

--- a/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.ml
+++ b/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.ml
@@ -467,7 +467,7 @@ module FDU = struct
     match res.result with
     | Some js ->
       Lwt.return @@ (JSON.to_string js)
-    | None -> raise @@ FException (`InternalError (`Msg ("Error during connection point connection to interface")))
+    | None -> raise @@ FException (`InternalError (`Msg ( Apero.Option.get res.error_msg)))
 
 
   let disconnect_interface_from_cp face instanceid nodeid api =

--- a/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.ml
+++ b/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.ml
@@ -153,10 +153,11 @@ module Network = struct
     match%lwt Yaks_connector.Global.Actual.get_node_network api.sysid api.tenantid nodeid descriptor.uuid api.yconnector with
     | Some netr -> Lwt.return netr
     | None ->
+      let r =  wait_network_in_node api.sysid api.tenantid nodeid descriptor.uuid api in
       let%lwt res = Yaks_connector.Global.Actual.create_network_in_node api.sysid api.tenantid nodeid descriptor api.yconnector in
       ( match res.result with
         | Some js ->
-          wait_network_in_node api.sysid api.tenantid nodeid descriptor.uuid api >>= fun _ ->
+          r >>= fun _ ->
           Lwt.return @@ FTypesRecord.virtual_network_of_string (JSON.to_string js)
         | None -> raise @@ FException (`InternalError (`Msg ("Error during network creation"))))
 

--- a/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.ml
+++ b/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.ml
@@ -178,7 +178,7 @@ module Network = struct
     let%lwt res = Yaks_connector.Global.Actual.create_cp_in_node api.sysid api.tenantid nodeid descriptor api.yconnector in
     match res.result with
     | Some js ->
-      wait_port_in_node api.sysid api.tenantid nodeid "" api >>= fun _ ->
+      wait_port_in_node api.sysid api.tenantid nodeid (Apero.Option.get descriptor.uuid) api >>= fun _ ->
       Lwt.return @@ Infra.Descriptors.Network.connection_point_record_of_string (JSON.to_string js)
     | None -> raise @@ FException (`InternalError (`Msg ("Error during connection point creation")))
 

--- a/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.ml
+++ b/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.ml
@@ -412,7 +412,7 @@ module FDU = struct
     match res.result with
     | Some js ->
       Lwt.return @@ (JSON.to_string js)
-    | None -> raise @@ FException (`InternalError (`Msg ("Error during connection point creation")))
+    | None -> raise @@ FException (`InternalError (`Msg ("Error during connection point connection")))
 
 
   let disconnect_interface_from_cp face instanceid nodeid api =

--- a/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.ml
+++ b/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.ml
@@ -107,7 +107,7 @@ module Network = struct
       | false ->
         (match port with
          | Some port ->
-           (if (String.compare port.uuid portid) == 0 then
+           (if (String.compare port.cp_id portid) == 0 then
               Fos_core.MVar.put var port
             else
               Lwt.return_unit)

--- a/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.mli
+++ b/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.mli
@@ -38,10 +38,27 @@ module Network : sig
 
   val add_network : FTypes.virtual_network -> api -> bool Lwt.t
   val remove_network : string -> api -> bool Lwt.t
-  val add_connection_point : User.Descriptors.FDU.connection_point_descriptor -> api -> bool Lwt.t
-  val remove_connection_point : string -> api -> bool Lwt.t
   val list_networks : api -> (FTypes.virtual_network list) Lwt.t
-  val list_connection_points : api -> (User.Descriptors.FDU.connection_point_descriptor list) Lwt.t
+
+  val add_connection_point : User.Descriptors.Network.connection_point_descriptor -> api -> bool Lwt.t
+  val remove_connection_point : string -> api -> bool Lwt.t
+  val list_connection_points : api -> (User.Descriptors.Network.connection_point_descriptor list) Lwt.t
+
+
+  val add_network_to_node : FTypes.virtual_network -> string -> api -> FTypesRecord.virtual_network Lwt.t
+  val remove_network_from_node : string -> string -> api -> FTypesRecord.virtual_network Lwt.t
+
+  val add_connection_point_to_node : User.Descriptors.Network.connection_point_descriptor -> string -> api -> Infra.Descriptors.Network.connection_point_record Lwt.t
+  val remove_connection_point_from_node : string -> string -> api -> Infra.Descriptors.Network.connection_point_record Lwt.t
+
+
+  val connect_cp_to_network : string -> string -> string -> api -> string Lwt.t
+  val disconnect_cp_from_network : string -> string -> api -> string Lwt.t
+
+  val create_floating_ip : string -> api -> FTypes.floating_ip Lwt.t
+  val delete_floating_ip : string -> string -> api -> FTypes.floating_ip Lwt.t
+  val assing_floating_ip : string -> string -> string -> api -> FTypes.floating_ip Lwt.t
+  val retain_floating_ip : string -> string -> string -> api -> FTypes.floating_ip Lwt.t
 
 end
 
@@ -74,6 +91,10 @@ module FDU : sig
   val info : string -> api -> User.Descriptors.FDU.descriptor Lwt.t
   val instance_info : string -> api -> Infra.Descriptors.FDU.record Lwt.t
   val list : api -> (User.Descriptors.FDU.descriptor list) Lwt.t
+
+
+  val connect_interface_to_cp : string -> string -> string -> string -> api -> string Lwt.t
+  val disconnect_interface_from_cp : string -> string -> string -> api -> string Lwt.t
 
 end
 

--- a/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.mli
+++ b/src/api/ocaml/fimapi/fos-fim-api/fos_fim_api.mli
@@ -50,6 +50,7 @@ module Network : sig
 
   val add_connection_point_to_node : User.Descriptors.Network.connection_point_descriptor -> string -> api -> Infra.Descriptors.Network.connection_point_record Lwt.t
   val remove_connection_point_from_node : string -> string -> api -> Infra.Descriptors.Network.connection_point_record Lwt.t
+  val get_node_from_connection_point : string -> api -> string option Lwt.t
 
 
   val connect_cp_to_network : string -> string -> string -> api -> string Lwt.t

--- a/src/api/python/api/fog05/__init__.py
+++ b/src/api/python/api/fog05/__init__.py
@@ -15,5 +15,6 @@
 
 from fog05.fimapi import FIMAPI
 from fog05.faemapi import FAEMAPI
+from fog05.feoapi import FEOAPI
 from fog05.yaks_connector import Yaks_Connector
 from fog05.yaks_connector import Yaks_Constraint_Connector

--- a/src/api/python/api/fog05/faemapi.py
+++ b/src/api/python/api/fog05/faemapi.py
@@ -56,7 +56,7 @@ class FAEMAPI(object):
             n = random.choice(nodes)
             res = self.connector.glob.actual.onboard_ae_from_node(self.sysid, self.tenantid, n, descriptor.to_json())
             if res.get('result') is None:
-                raise SystemError('Error during onboarding {}'.format(res['error']))
+                raise SystemError('Error during onboarding {} - {}'.format(res['error'], res['error_msg']))
             return AtomicEntity(res['result'])
 
 
@@ -67,7 +67,7 @@ class FAEMAPI(object):
             n = random.choice(nodes)
             res =  self.connector.glob.actual.instantiate_ae_from_node(self.sysid, self.tenantid, n, ae_id)
             if res.get('result') is None:
-                raise SystemError('Error during instantiation {}'.format(res['error']))
+                raise SystemError('Error during instantiation {} - {}'.format(res['error'], res['error_msg']))
             return AtomicEntityRecord(res['result'])
 
         def offload(self, ae_id):
@@ -77,7 +77,7 @@ class FAEMAPI(object):
             n = random.choice(nodes)
             res =  self.connector.glob.actual.offload_ae_from_node(self.sysid, self.tenantid, n, ae_id)
             if res.get('result') is None:
-                raise SystemError('Error during offloading {}'.format(res['error']))
+                raise SystemError('Error during offloading {} - {}'.format(res['error'], res['error_msg']))
             return AtomicEntity(res['result'])
 
 
@@ -88,7 +88,7 @@ class FAEMAPI(object):
             n = random.choice(nodes)
             res = self.connector.glob.actual.terminate_ae_from_node(self.sysid, self.tenantid, n, ae_instance_id)
             if res.get('result') is None:
-                raise SystemError('Error during termination {}'.format(res['error']))
+                raise SystemError('Error during termination {} - {}'.format(res['error'], res['error_msg']))
             return AtomicEntityRecord(res['result'])
 
         def get_atomic_entity_descriptor(self, ae_id):

--- a/src/api/python/api/fog05/faemapi.py
+++ b/src/api/python/api/fog05/faemapi.py
@@ -16,7 +16,8 @@
 import random
 from fog05.yaks_connector import Yaks_Connector
 from fog05.interfaces import Constants
-
+from fog05.interfaces.AtomicEntity import AtomicEntity
+from fog05.interfaces.AtomicEntityRecord import AtomicEntityRecord
 
 class FAEMAPI(object):
     '''
@@ -30,12 +31,12 @@ class FAEMAPI(object):
         self.connector = Yaks_Connector(locator)
         self.sysid = sysid
         self.tenantid = tenantid
-        self.atomic_entity = self.AtomicEntity(self.connector, self.sysid, self.tenantid)
+        self.atomic_entity = self.AtomicEntityAPI(self.connector, self.sysid, self.tenantid)
 
     def close(self):
         self.connector.close()
 
-    class AtomicEntity(object):
+    class AtomicEntityAPI(object):
 
         def __init__(self, connector=None, sysid=Constants.default_system_id,
             tenantid=Constants.default_tenant_id):
@@ -47,14 +48,16 @@ class FAEMAPI(object):
             self.tenantid = tenantid
 
         def onboard(self, descriptor):
+            if not isinstance(descriptor,AtomicEntity):
+                raise ValueError("descriptor should be of type AtomicEntity")
             nodes = self.connector.glob.actual.get_all_nodes(self.sysid, self.tenantid)
             if len(nodes) == 0:
                 raise SystemError("No nodes in the system!")
             n = random.choice(nodes)
-            res = self.connector.glob.actual.onboard_ae_from_node(self.sysid, self.tenantid, n, descriptor)
+            res = self.connector.glob.actual.onboard_ae_from_node(self.sysid, self.tenantid, n, descriptor.to_json())
             if res.get('result') is None:
                 raise SystemError('Error during onboarding {}'.format(res['error']))
-            return res['result']
+            return AtomicEntity(res['result'])
 
 
         def instantiate(self, ae_id):
@@ -65,7 +68,7 @@ class FAEMAPI(object):
             res =  self.connector.glob.actual.instantiate_ae_from_node(self.sysid, self.tenantid, n, ae_id)
             if res.get('result') is None:
                 raise SystemError('Error during instantiation {}'.format(res['error']))
-            return res['result']
+            return AtomicEntityRecord(res['result'])
 
         def offload(self, ae_id):
             nodes = self.connector.glob.actual.get_all_nodes(self.sysid, self.tenantid)
@@ -75,7 +78,7 @@ class FAEMAPI(object):
             res =  self.connector.glob.actual.offload_ae_from_node(self.sysid, self.tenantid, n, ae_id)
             if res.get('result') is None:
                 raise SystemError('Error during offloading {}'.format(res['error']))
-            return res['result']
+            return AtomicEntity(res['result'])
 
 
         def terminate(self, ae_instance_id):
@@ -86,15 +89,15 @@ class FAEMAPI(object):
             res = self.connector.glob.actual.terminate_ae_from_node(self.sysid, self.tenantid, n, ae_instance_id)
             if res.get('result') is None:
                 raise SystemError('Error during termination {}'.format(res['error']))
-            return res['result']
+            return AtomicEntityRecord(res['result'])
 
         def get_atomic_entity_descriptor(self, ae_id):
             res = self.connector.glob.actual.get_catalog_atomic_entity_info(self.sysid, self.tenantid, ae_id)
-            return res
+            return AtomicEntity(res)
 
         def get_atomic_entity_instance_info(self, instance_id):
             res = self.connector.glob.actual.get_records_atomic_entity_info(self.sysid, self.tenantid, "*", instance_id)
-            return res
+            return AtomicEntityRecord(res)
 
 
         def list(self):

--- a/src/api/python/api/fog05/feoapi.py
+++ b/src/api/python/api/fog05/feoapi.py
@@ -56,7 +56,7 @@ class FEOAPI(object):
             n = random.choice(nodes)
             res = self.connector.glob.actual.onboard_entity_from_node(self.sysid, self.tenantid, n, descriptor.to_json())
             if res.get('result') is None:
-                raise SystemError('Error during onboarding {}'.format(res['error']))
+                raise SystemError('Error during onboarding {} - {}'.format(res['error'], res['error_msg']))
             return Entity(res['result'])
 
 
@@ -67,7 +67,7 @@ class FEOAPI(object):
             n = random.choice(nodes)
             res =  self.connector.glob.actual.instantiate_entity_from_node(self.sysid, self.tenantid, n, e_id)
             if res.get('result') is None:
-                raise SystemError('Error during instantiation {}'.format(res['error']))
+                raise SystemError('Error during instantiation {} - {}'.format(res['error'], res['error_msg']))
             return EntityRecord(res['result'])
 
         def offload(self, e_id):
@@ -77,7 +77,7 @@ class FEOAPI(object):
             n = random.choice(nodes)
             res =  self.connector.glob.actual.offload_entity_from_node(self.sysid, self.tenantid, n, e_id)
             if res.get('result') is None:
-                raise SystemError('Error during offloading {}'.format(res['error']))
+                raise SystemError('Error during offloading {} - {}'.format(res['error'], res['error_msg']))
             return Entity(res['result'])
 
 
@@ -88,7 +88,7 @@ class FEOAPI(object):
             n = random.choice(nodes)
             res = self.connector.glob.actual.terminate_entity_from_node(self.sysid, self.tenantid, n, e_instance_id)
             if res.get('result') is None:
-                raise SystemError('Error during termination {}'.format(res['error']))
+                raise SystemError('Error during termination {} - {}'.format(res['error'], res['error_msg']))
             return EntityRecord(res['result'])
 
         def get_entity_descriptor(self, e_id):

--- a/src/api/python/api/fog05/feoapi.py
+++ b/src/api/python/api/fog05/feoapi.py
@@ -10,7 +10,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 #
-# Contributors: Gabriele Baldoni, ADLINK Technology Inc. - FAEM API
+# Contributors: Gabriele Baldoni, ADLINK Technology Inc. - FEO API
 
 
 import random
@@ -18,7 +18,7 @@ from fog05.yaks_connector import Yaks_Connector
 from fog05.interfaces import Constants
 
 
-class FAEMAPI(object):
+class FEOAPI(object):
     '''
         This class allow the interaction with fog05 FIM
     '''
@@ -30,12 +30,12 @@ class FAEMAPI(object):
         self.connector = Yaks_Connector(locator)
         self.sysid = sysid
         self.tenantid = tenantid
-        self.atomic_entity = self.AtomicEntity(self.connector, self.sysid, self.tenantid)
+        self.entity = self.Entity(self.connector, self.sysid, self.tenantid)
 
     def close(self):
         self.connector.close()
 
-    class AtomicEntity(object):
+    class Entity(object):
 
         def __init__(self, connector=None, sysid=Constants.default_system_id,
             tenantid=Constants.default_tenant_id):
@@ -51,55 +51,55 @@ class FAEMAPI(object):
             if len(nodes) == 0:
                 raise SystemError("No nodes in the system!")
             n = random.choice(nodes)
-            res = self.connector.glob.actual.onboard_ae_from_node(self.sysid, self.tenantid, n, descriptor)
+            res = self.connector.glob.actual.onboard_entity_from_node(self.sysid, self.tenantid, n, descriptor)
             if res.get('result') is None:
                 raise SystemError('Error during onboarding {}'.format(res['error']))
             return res['result']
 
 
-        def instantiate(self, ae_id):
+        def instantiate(self, e_id):
             nodes = self.connector.glob.actual.get_all_nodes(self.sysid, self.tenantid)
             if len(nodes) == 0:
                 raise SystemError("No nodes in the system!")
             n = random.choice(nodes)
-            res =  self.connector.glob.actual.instantiate_ae_from_node(self.sysid, self.tenantid, n, ae_id)
+            res =  self.connector.glob.actual.instantiate_entity_from_node(self.sysid, self.tenantid, n, e_id)
             if res.get('result') is None:
                 raise SystemError('Error during instantiation {}'.format(res['error']))
             return res['result']
 
-        def offload(self, ae_id):
+        def offload(self, e_id):
             nodes = self.connector.glob.actual.get_all_nodes(self.sysid, self.tenantid)
             if len(nodes) == 0:
                 raise SystemError("No nodes in the system!")
             n = random.choice(nodes)
-            res =  self.connector.glob.actual.offload_ae_from_node(self.sysid, self.tenantid, n, ae_id)
+            res =  self.connector.glob.actual.offload_entity_from_node(self.sysid, self.tenantid, n, e_id)
             if res.get('result') is None:
                 raise SystemError('Error during offloading {}'.format(res['error']))
             return res['result']
 
 
-        def terminate(self, ae_instance_id):
+        def terminate(self, e_instance_id):
             nodes = self.connector.glob.actual.get_all_nodes(self.sysid, self.tenantid)
             if len(nodes) == 0:
                 raise SystemError("No nodes in the system!")
             n = random.choice(nodes)
-            res = self.connector.glob.actual.terminate_ae_from_node(self.sysid, self.tenantid, n, ae_instance_id)
+            res = self.connector.glob.actual.terminate_entity_from_node(self.sysid, self.tenantid, n, e_instance_id)
             if res.get('result') is None:
                 raise SystemError('Error during termination {}'.format(res['error']))
             return res['result']
 
-        def get_atomic_entity_descriptor(self, ae_id):
-            res = self.connector.glob.actual.get_catalog_atomic_entity_info(self.sysid, self.tenantid, ae_id)
+        def get_entity_descriptor(self, e_id):
+            res = self.connector.glob.actual.get_catalog_entity_info(self.sysid, self.tenantid, e_id)
             return res
 
-        def get_atomic_entity_instance_info(self, instance_id):
-            res = self.connector.glob.actual.get_records_atomic_entity_info(self.sysid, self.tenantid, "*", instance_id)
+        def get_entity_instance_info(self, instance_id):
+            res = self.connector.glob.actual.get_records_entity_info(self.sysid, self.tenantid, "*", instance_id)
             return res
-
 
         def list(self):
-            return self.connector.glob.actual.get_catalog_all_atomic_entities(self.sysid, self.tenantid)
+            return self.connector.glob.actual.get_catalog_all_entities(self.sysid, self.tenantid)
 
-        def instance_list(self, aeid):
-            return  self.connector.glob.actual.get_records_all_atomic_entity_instances(self.sysid, self.tenantid, aeid)
+        def instance_list(self, entity_id):
+            return  self.connector.glob.actual.get_records_all_entity_instances(self.sysid, self.tenantid, entity_id)
+
 

--- a/src/api/python/api/fog05/fimapi.py
+++ b/src/api/python/api/fog05/fimapi.py
@@ -526,8 +526,8 @@ class FIMAPI(object):
             '''
             res = self.connector.glob.desired.remove_catalog_fdu_info(
                 self.sysid, self.tenantid, fdu_uuid)
-            if res.get('result') is None:
-                raise SystemError('Error during onboarding {}'.format(res['error']))
+            # if res.get('result') is None:
+            #     raise SystemError('Error during onboarding {}'.format(res['error']))
 
             return fdu_uuid
 

--- a/src/api/python/api/fog05/fimapi.py
+++ b/src/api/python/api/fog05/fimapi.py
@@ -46,7 +46,7 @@ class FIMAPI(object):
         self.node = self.Node(self.connector, self.sysid, self.tenantid)
         self.plugin = self.Plugin(self.connector, self.sysid, self.tenantid)
         self.network = self.Network(self.connector, self.sysid, self.tenantid)
-        self.fdu = self.FDU(self.connector, self.sysid, self.tenantid)
+        self.fdu = self.FDUAPI(self.connector, self.sysid, self.tenantid)
         self.image = self.Image(self.connector, self.sysid, self.tenantid)
         self.flavor = self.Flavor(self.connector, self.sysid, self.tenantid)
 
@@ -444,7 +444,7 @@ class FIMAPI(object):
             '''
             pass
 
-    class FDU(object):
+    class FDUAPI(object):
         '''
 
         This class encapsulates the api for interaction with entities
@@ -502,6 +502,8 @@ class FIMAPI(object):
             :return the fdu uuid
 
             '''
+            if not isinstance(descriptor, FDU):
+                raise ValueError("descriptor should be of type FDU")
             nodes = self.connector.glob.actual.get_all_nodes(self.sysid, self.tenantid)
             if len(nodes) == 0:
                 raise SystemError("No nodes in the system!")
@@ -510,7 +512,7 @@ class FIMAPI(object):
             res = self.connector.glob.actual.onboard_fdu_from_node(self.sysid, self.tenantid, n, descriptor.get_uuid(), descriptor.to_json())
             if res.get('result') is None:
                 raise SystemError('Error during onboarding {}'.format(res['error']))
-            return res['result']
+            return FDU(res['result'])
 
 
         def offload(self, fdu_uuid, wait=True):
@@ -551,7 +553,7 @@ class FIMAPI(object):
                 raise ValueError('Got Error {}'.format(res['error']))
             if wait:
                 self.__wait_node_fdu_state_change(res['result']['uuid'],'DEFINE')
-            return res['result']
+            return InfraFDU(res['result'])
 
 
         def undefine(self, instanceid, wait=True):
@@ -800,8 +802,8 @@ class FIMAPI(object):
             :param nodeid: node where instantiate
             :return instance uuid
             '''
-            instance_info= self.define(fduid, nodeid)
-            instance_id = instance_info['uuid']
+            instance_info = self.define(fduid, nodeid)
+            instance_id = instance_info.get_uuid()
             self.configure(instance_id)
             self.start(instance_id)
             return instance_info
@@ -847,7 +849,7 @@ class FIMAPI(object):
             '''
             data = self.connector.glob.actual.get_node_fdu_instance(self.sysid, self.tenantid, "*", instanceid)
             fdu = InfraFDU(data)
-            return fdu.to_json()
+            return fdu
 
         def get_nodes(self, fdu_uuid):
             '''
@@ -899,7 +901,7 @@ class FIMAPI(object):
             :param node_uuid: optional node uuid
             :return: dictionary {node uuid: {entity uuid: instance list} list}
             '''
-            return self.connector.glob.actual.get_catalog_all_fdus(self.sysid, self.tenantid)
+            [FDU(x) for x in self.connector.glob.actual.get_catalog_all_fdus(self.sysid, self.tenantid)]
 
 
     class Image(object):

--- a/src/api/python/api/fog05/interfaces/AtomicEntity.py
+++ b/src/api/python/api/fog05/interfaces/AtomicEntity.py
@@ -134,4 +134,4 @@ class AtomicEntity(object):
         return self.fdus
 
     def __str__(self):
-        return "Name : {} ID: {}".format(self.name, self.id)
+        return "Name : {} ID: {} UUID: {}".format(self.name, self.id, self.uuid)

--- a/src/api/python/api/fog05/interfaces/AtomicEntity.py
+++ b/src/api/python/api/fog05/interfaces/AtomicEntity.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors: Gabriele Baldoni, ADLINK Technology Inc.
+# Atomic Entity Parsers and Python Class
+
+
+import json
+from fog05_im import user_atomic_entity
+from pyangbind.lib.serialise import pybindJSONDecoder
+from pyangbind.lib.serialise import pybindJSONEncoder
+from collections import OrderedDict
+from fog05.interfaces.FDU import FDU
+
+
+class AtomicEntity(object):
+
+    def __init__(self, data=None):
+        '''
+
+        Constructor for the FDU Descriptor
+        :param data dictionary containing the FDU descriptor
+
+        :return the FDU object
+
+        '''
+
+        self.ae = user_atomic_entity.user_atomic_entity()
+        self.encoder = pybindJSONEncoder()
+        self.id = None
+        self.uuid = None
+        self.name = None
+        self.description = None
+        self.fdus = []
+        self.internal_virtual_links = []
+        self.connection_points = []
+        self.depends_on = []
+        if data is not None:
+            pybindJSONDecoder.load_ietf_json({'ae_descriptor':data}, None, None, obj=self.ae)
+            self.enforce()
+
+            self.id = self.ae.ae_descriptor.id
+            self.name = data.get('name')
+            self.description = data.get('description')
+            self.uuid = data.get('uuid', None)
+            self.fdus = [FDU(x) for x in data.get('fdus')]
+            self.internal_virtual_links = data.get('internal_virtual_links')
+            self.connection_points = data.get('connection_points')
+            self.depends_on = data.get('depends_on')
+
+
+
+    def enforce(self):
+        if self.ae.ae_descriptor.id == '':
+            raise ValueError('AtomicEntity.ID cannot be empty')
+
+        if self.ae.ae_descriptor.name == '':
+            raise ValueError('AtomicEntity.Name cannot be empty')
+
+        if len (self.ae.ae_descriptor.fdus) == 0:
+            raise ValueError('AtomicEntity.FDUS cannot be empty')
+
+    def to_json(self):
+        data = {
+            'uuid': self.uuid,
+            'id': self.id,
+            'name': self.name,
+            'description': self.description,
+            'fdus': [x.to_json() for x in self.fdus],
+            'internal_virtual_links': self.internal_virtual_links,
+            'connection_points': self.connection_points,
+            'depends_on': self.depends_on,
+        }
+        check_obj = user_atomic_entity.user_atomic_entity()
+        pybindJSONDecoder.load_ietf_json({'ae_descriptor':data}, None, None, obj=check_obj)
+        return data
+
+    def get_uuid(self):
+        return self.uuid
+
+    def set_uuid(self, uuid) :
+        self.uuid = uuid
+
+    def get_id(self):
+        return self.id
+
+    def set_id(self, id) :
+        self.id = id
+
+    def get_description(self):
+        return self.description
+
+    def set_description(self, description) :
+        self.description = description
+
+    def get_name(self):
+        return self.name
+
+    def set_name(self, name) :
+        self.name = name
+
+    def get_connection_points(self):
+        return self.connection_points
+
+    def set_connection_points(self, connection_points) :
+        self.connection_points = connection_points
+
+    def get_depends_on(self):
+        return self.depends_on
+
+    def set_depends_on(self, depends_on) :
+        self.depends_on = depends_on
+
+
+    def set_internal_virtual_links(self, virtual_links):
+        self.internal_virtual_links = virtual_links
+
+    def get_internal_virtual_links(self):
+        return self.internal_virtual_links
+
+    def set_fdus(self, fdus):
+        self.fdus = fdus
+
+    def get_fdus(self):
+        return self.fdus
+
+    def __str__(self):
+        return "Name : {} ID: {}".format(self.name, self.id)

--- a/src/api/python/api/fog05/interfaces/AtomicEntityRecord.py
+++ b/src/api/python/api/fog05/interfaces/AtomicEntityRecord.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors: Gabriele Baldoni, ADLINK Technology Inc.
+# Atomic Entity Parsers and Python Class
+
+
+import json
+from fog05_im import infra_atomic_entity
+from pyangbind.lib.serialise import pybindJSONDecoder
+from pyangbind.lib.serialise import pybindJSONEncoder
+from collections import OrderedDict
+from fog05.interfaces.InfraFDU import InfraFDU
+
+
+class AtomicEntityRecord(object):
+
+    def __init__(self, data=None):
+        '''
+
+        Constructor for the FDU Descriptor
+        :param data dictionary containing the FDU descriptor
+
+        :return the FDU object
+
+        '''
+
+        self.ae = infra_atomic_entity.infra_atomic_entity()
+        self.encoder = pybindJSONEncoder()
+        self.atomic_entity_id = None
+        self.uuid = None
+        self.fdus = []
+        self.internal_virtual_links = []
+        self.connection_points = []
+        self.depends_on = []
+        if data is not None:
+            pybindJSONDecoder.load_ietf_json({'ae_record':data}, None, None, obj=self.ae)
+            self.enforce()
+
+            self.atomic_entity_id = self.ae.ae_record.atomic_entity_id
+            self.uuid = self.ae.ae_record.uuid
+            self.fdus = [InfraFDU(x) for x in data.get('fdus')]
+            self.internal_virtual_links = data.get('internal_virtual_links')
+            self.connection_points = data.get('connection_points')
+            self.depends_on = data.get('depends_on')
+
+
+
+    def enforce(self):
+        if self.ae.ae_record.atomic_entity_id == '':
+            raise ValueError('AtomicEntityRecord.atomic_entity_id cannot be empty')
+
+        if self.ae.ae_record.uuid == '':
+            raise ValueError('AtomicEntityRecord.Name cannot be empty')
+
+        if len (self.ae.ae_record.fdus) == 0:
+            raise ValueError('AtomicEntityRecord.FDUS cannot be empty')
+
+    def to_json(self):
+        data = {
+            'uuid': self.uuid,
+            'atomic_entity_id': self.atomic_entity_id,
+            'fdus': [x.to_json() for x in self.fdus],
+            'internal_virtual_links': self.internal_virtual_links,
+            'connection_points': self.connection_points,
+            'depends_on': self.depends_on,
+        }
+        check_obj = infra_atomic_entity.infra_atomic_entity()
+        pybindJSONDecoder.load_ietf_json({'ae_record':data}, None, None, obj=check_obj)
+        return data
+
+    def get_uuid(self):
+        return self.uuid
+
+    def set_uuid(self, uuid) :
+        self.uuid = uuid
+
+    def get_atomic_entity_id(self):
+        return self.atomic_entity_id
+
+    def set_atomic_entity_id(self, atomic_entity_id) :
+        self.atomic_entity_id = atomic_entity_id
+
+    def get_connection_points(self):
+        return self.connection_points
+
+    def set_connection_points(self, connection_points) :
+        self.connection_points = connection_points
+
+    def get_depends_on(self):
+        return self.depends_on
+
+    def set_depends_on(self, depends_on) :
+        self.depends_on = depends_on
+
+
+    def set_internal_virtual_links(self, virtual_links):
+        self.internal_virtual_links = virtual_links
+
+    def get_internal_virtual_links(self):
+        return self.internal_virtual_links
+
+    def set_fdus(self, fdus):
+        self.fdus = fdus
+
+    def get_fdus(self):
+        return self.fdus
+
+    def __str__(self):
+        return "UUID : {} Atomic Entity ID: {}".format(self.uuid, self.atomic_entity_id)

--- a/src/api/python/api/fog05/interfaces/AtomicEntityRecord.py
+++ b/src/api/python/api/fog05/interfaces/AtomicEntityRecord.py
@@ -20,7 +20,7 @@ from pyangbind.lib.serialise import pybindJSONDecoder
 from pyangbind.lib.serialise import pybindJSONEncoder
 from collections import OrderedDict
 from fog05.interfaces.InfraFDU import InfraFDU
-
+import copy
 
 class AtomicEntityRecord(object):
 
@@ -43,7 +43,15 @@ class AtomicEntityRecord(object):
         self.connection_points = []
         self.depends_on = []
         if data is not None:
-            pybindJSONDecoder.load_ietf_json({'ae_record':data}, None, None, obj=self.ae)
+
+            def conv(x):
+                x['properties'] = json.dumps(x['properties'])
+                return x
+            cdata = copy.deepcopy(data)
+            xs = list(map(conv, cdata['connection_points']))
+            cdata['connection_points'] = xs
+
+            pybindJSONDecoder.load_ietf_json({'ae_record':cdata}, None, None, obj=self.ae)
             self.enforce()
 
             self.atomic_entity_id = self.ae.ae_record.atomic_entity_id
@@ -75,7 +83,15 @@ class AtomicEntityRecord(object):
             'depends_on': self.depends_on,
         }
         check_obj = infra_atomic_entity.infra_atomic_entity()
-        pybindJSONDecoder.load_ietf_json({'ae_record':data}, None, None, obj=check_obj)
+
+        def conv(x):
+            x['properties'] = json.dumps(x['properties'])
+            return x
+        cdata = copy.deepcopy(data)
+        xs = list(map(conv, cdata['connection_points']))
+        cdata['connection_points'] = xs
+
+        pybindJSONDecoder.load_ietf_json({'ae_record':cdata}, None, None, obj=check_obj)
         return data
 
     def get_uuid(self):

--- a/src/api/python/api/fog05/interfaces/Entity.py
+++ b/src/api/python/api/fog05/interfaces/Entity.py
@@ -40,7 +40,6 @@ class Entity(object):
 
         self.atomic_entities = []
         self.virtual_links = []
-        self.connection_points = []
         if data is not None:
             pybindJSONDecoder.load_ietf_json({'entity_descriptor':data}, None, None, obj=self.e)
             self.enforce()
@@ -51,7 +50,6 @@ class Entity(object):
             self.uuid = data.get('uuid', None)
             self.atomic_entities = data.get('atomic_entities')
             self.virtual_links = data.get('virtual_links')
-            self.connection_points = data.get('connection_points')
 
 
     def enforce(self):
@@ -71,8 +69,7 @@ class Entity(object):
             'name': self.name,
             'description': self.description,
             'atomic_entities': self.atomic_entities,
-            'virtual_links': self.virtual_links,
-            'connection_points': self.connection_points
+            'virtual_links': self.virtual_links
         }
         check_obj = user_entity.user_entity()
         pybindJSONDecoder.load_ietf_json({'entity_descriptor':data}, None, None, obj=check_obj)

--- a/src/api/python/api/fog05/interfaces/Entity.py
+++ b/src/api/python/api/fog05/interfaces/Entity.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2014,2019 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors: Gabriele Baldoni, ADLINK Technology Inc.
+# Entity Parsers and Python Class
+
+
+import json
+from fog05_im import user_entity
+from pyangbind.lib.serialise import pybindJSONDecoder
+from pyangbind.lib.serialise import pybindJSONEncoder
+from collections import OrderedDict
+
+
+class Entity(object):
+
+    def __init__(self, data=None):
+        '''
+
+        Constructor for the FDU Descriptor
+        :param data dictionary containing the FDU descriptor
+
+        :return the FDU object
+
+        '''
+
+        self.e = user_entity.user_entity()
+        self.encoder = pybindJSONEncoder()
+        self.id = None
+        self.uuid = None
+
+        self.atomic_entities = []
+        self.virtual_links = []
+        self.connection_points = []
+        if data is not None:
+            pybindJSONDecoder.load_ietf_json({'entity_descriptor':data}, None, None, obj=self.e)
+            self.enforce()
+
+            self.id = self.e.entity_descriptor.id
+            self.name = data.get('name')
+            self.description = data.get('description')
+            self.uuid = data.get('uuid', None)
+            self.atomic_entities = data.get('atomic_entities')
+            self.virtual_links = data.get('virtual_links')
+            self.connection_points = data.get('connection_points')
+
+
+    def enforce(self):
+        if self.e.entity_descriptor.id == '':
+            raise ValueError('Entity.ID cannot be empty')
+
+        if self.e.entity_descriptor.name == '':
+            raise ValueError('Entity.Name cannot be empty')
+
+        if len (self.e.entity_descriptor.atomic_entities) == 0:
+            raise ValueError('Entity.atomic_entities cannot be empty')
+
+    def to_json(self):
+        data = {
+            'uuid': self.uuid,
+            'id': self.id,
+            'name': self.name,
+            'description': self.description,
+            'atomic_entities': self.atomic_entities,
+            'virtual_links': self.virtual_links,
+            'connection_points': self.connection_points
+        }
+        check_obj = user_entity.user_entity()
+        pybindJSONDecoder.load_ietf_json({'entity_descriptor':data}, None, None, obj=check_obj)
+        return data
+
+    def get_uuid(self):
+        return self.uuid
+
+    def set_uuid(self, uuid) :
+        self.uuid = uuid
+
+    def get_id(self):
+        return self.id
+
+    def set_id(self, id) :
+        self.id = id
+
+    def get_description(self):
+        return self.description
+
+    def set_description(self, description) :
+        self.description = description
+
+    def get_name(self):
+        return self.name
+
+    def set_name(self, name) :
+        self.name = name
+
+    def get_connection_points(self):
+        return self.connection_points
+
+    def set_connection_points(self, connection_points) :
+        self.connection_points = connection_points
+
+    def set_virtual_links(self, virtual_links):
+        self.virtual_links = virtual_links
+
+    def get_virtual_links(self):
+        return self.virtual_links
+
+    def set_atomic_entities(self, atomic_entities):
+        self.atomic_entities = atomic_entities
+
+    def get_atomic_entities(self):
+        return self.atomic_entities
+
+    def __str__(self):
+        return "Name : {} ID: {}".format(self.name, self.id)

--- a/src/api/python/api/fog05/interfaces/Entity.py
+++ b/src/api/python/api/fog05/interfaces/Entity.py
@@ -121,4 +121,4 @@ class Entity(object):
         return self.atomic_entities
 
     def __str__(self):
-        return "Name : {} ID: {}".format(self.name, self.id)
+        return "Name : {} ID: {} UUID:{}".format(self.name, self.id, self.uuid)

--- a/src/api/python/api/fog05/interfaces/EntityRecord.py
+++ b/src/api/python/api/fog05/interfaces/EntityRecord.py
@@ -21,7 +21,7 @@ from pyangbind.lib.serialise import pybindJSONEncoder
 from collections import OrderedDict
 
 
-class Entity(object):
+class EntityRecord(object):
 
     def __init__(self, data=None):
         '''

--- a/src/api/python/api/fog05/interfaces/EntityRecord.py
+++ b/src/api/python/api/fog05/interfaces/EntityRecord.py
@@ -52,7 +52,7 @@ class EntityRecord(object):
 
 
     def enforce(self):
-        if self.e.entity_record.id == '':
+        if self.e.entity_record.entity_id == '':
             raise ValueError('EntityRecord.ID cannot be empty')
 
         if self.e.entity_record.uuid == '':

--- a/src/api/python/api/fog05/interfaces/EntityRecord.py
+++ b/src/api/python/api/fog05/interfaces/EntityRecord.py
@@ -39,7 +39,6 @@ class EntityRecord(object):
         self.uuid = None
         self.atomic_entities = []
         self.virtual_links = []
-        self.connection_points = []
         if data is not None:
             pybindJSONDecoder.load_ietf_json({'entity_record':data}, None, None, obj=self.e)
             self.enforce()
@@ -48,7 +47,6 @@ class EntityRecord(object):
             self.uuid =  self.e.entity_record.uuid
             self.atomic_entities = data.get('atomic_entities')
             self.virtual_links = data.get('virtual_links')
-            self.connection_points = data.get('connection_points')
 
 
     def enforce(self):
@@ -66,8 +64,7 @@ class EntityRecord(object):
             'uuid': self.uuid,
             'entity_id': self.entity_id,
             'atomic_entities': self.atomic_entities,
-            'virtual_links': self.virtual_links,
-            'connection_points': self.connection_points
+            'virtual_links': self.virtual_links
         }
         check_obj = infra_entity.infra_entity()
         pybindJSONDecoder.load_ietf_json({'entity_record':data}, None, None, obj=check_obj)

--- a/src/api/python/api/fog05/interfaces/EntityRecord.py
+++ b/src/api/python/api/fog05/interfaces/EntityRecord.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2014,2019 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors: Gabriele Baldoni, ADLINK Technology Inc.
+# Entity Parsers and Python Class
+
+
+import json
+from fog05_im import infra_entity
+from pyangbind.lib.serialise import pybindJSONDecoder
+from pyangbind.lib.serialise import pybindJSONEncoder
+from collections import OrderedDict
+
+
+class Entity(object):
+
+    def __init__(self, data=None):
+        '''
+
+        Constructor for the FDU Descriptor
+        :param data dictionary containing the FDU descriptor
+
+        :return the FDU object
+
+        '''
+
+        self.e = infra_entity.infra_entity()
+        self.encoder = pybindJSONEncoder()
+        self.entity_id = None
+        self.uuid = None
+        self.atomic_entities = []
+        self.virtual_links = []
+        self.connection_points = []
+        if data is not None:
+            pybindJSONDecoder.load_ietf_json({'entity_record':data}, None, None, obj=self.e)
+            self.enforce()
+
+            self.entity_id = self.e.entity_record.entity_id
+            self.uuid =  self.e.entity_record.uuid
+            self.atomic_entities = data.get('atomic_entities')
+            self.virtual_links = data.get('virtual_links')
+            self.connection_points = data.get('connection_points')
+
+
+    def enforce(self):
+        if self.e.entity_record.id == '':
+            raise ValueError('EntityRecord.ID cannot be empty')
+
+        if self.e.entity_record.uuid == '':
+            raise ValueError('EntityRecord.UUID cannot be empty')
+
+        if len (self.e.entity_record.atomic_entities) == 0:
+            raise ValueError('EntityRecord.atomic_entities cannot be empty')
+
+    def to_json(self):
+        data = {
+            'uuid': self.uuid,
+            'entity_id': self.entity_id,
+            'atomic_entities': self.atomic_entities,
+            'virtual_links': self.virtual_links,
+            'connection_points': self.connection_points
+        }
+        check_obj = infra_entity.infra_entity()
+        pybindJSONDecoder.load_ietf_json({'entity_record':data}, None, None, obj=check_obj)
+        return data
+
+    def get_uuid(self):
+        return self.uuid
+
+    def set_uuid(self, uuid) :
+        self.uuid = uuid
+
+    def get_entity_id(self):
+        return self.entity_id
+
+    def set_entity_id(self, entity_id) :
+        self.entity_id = entity_id
+
+    def get_connection_points(self):
+        return self.connection_points
+
+    def set_connection_points(self, connection_points) :
+        self.connection_points = connection_points
+
+    def set_virtual_links(self, virtual_links):
+        self.virtual_links = virtual_links
+
+    def get_virtual_links(self):
+        return self.virtual_links
+
+    def set_atomic_entities(self, atomic_entities):
+        self.atomic_entities = atomic_entities
+
+    def get_atomic_entities(self):
+        return self.atomic_entities
+
+    def __str__(self):
+        return "UUID : {} Entity ID: {}".format(self.uuid, self.entity_id)

--- a/src/api/python/api/fog05/yaks_connector.py
+++ b/src/api/python/api/fog05/yaks_connector.py
@@ -1601,7 +1601,7 @@ class LAD(object):
     def add_plugin_eval(self, nodeid, pluginid, func_name, func):
         p = self.get_node_plugin_eval_path(nodeid, pluginid, func_name)
 
-        def cb(path, props):
+        def cb(path, **props):
             v = Value(json.dumps(func(**props)), encoding=Encoding.STRING)
             return v
         r = self.ws.register_eval(p, cb)

--- a/src/api/python/api/fog05/yaks_connector.py
+++ b/src/api/python/api/fog05/yaks_connector.py
@@ -1,3 +1,19 @@
+# Copyright (c) 2014,2019 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors: Gabriele Baldoni, ADLINK Technology Inc.
+# Connector and helper for YAKS
+
+
 import json
 from fog05.interfaces import Constants
 from yaks import Yaks, Value, Encoding, Change
@@ -72,6 +88,14 @@ class GAD(object):
         return Constants.create_path([self.prefix, sysid, 'tenants',
             tenantid, 'catalog', 'fdu', '*', 'info'])
 
+    def get_catalog_entity_info_path(self, sysid, tenantid, aeid):
+        return Constants.create_path([self.prefix, sysid, 'tenants',
+            tenantid, 'catalog', 'entities', aeid, 'info'])
+
+    def get_catalog_all_entities_selector(self, sysid, tenantid):
+        return Constants.create_path([self.prefix, sysid, 'tenants',
+            tenantid, 'catalog', 'entities', '*', 'info'])
+
     # RECORDS
 
     def get_records_atomic_entity_instance_info_path(self, sysid, tenantid, aeid, instanceid):
@@ -85,6 +109,18 @@ class GAD(object):
     def get_records_all_atomic_entities_instances_selector(self, sysid, tenantid):
         return Constants.create_path([self.prefix, sysid, 'tenants',
             tenantid, 'catalog', 'atomic-entities', '*', 'instances', '*' ,'info'])
+
+    def get_records_entity_instance_info_path(self, sysid, tenantid, aeid, instanceid):
+        return Constants.create_path([self.prefix, sysid, 'tenants',
+            tenantid, 'records', 'entities', aeid, 'instances', instanceid, 'info'])
+
+    def get_records_all_entity_instances_selector(self, sysid, tenantid, aeid):
+        return Constants.create_path([self.prefix, sysid, 'tenants',
+            tenantid, 'records', 'entities', aeid, 'instances','*', 'info'])
+
+    def get_records_all_entities_instances_selector(self, sysid, tenantid):
+        return Constants.create_path([self.prefix, sysid, 'tenants',
+            tenantid, 'catalog', 'entities', '*', 'instances', '*' ,'info'])
 
     # Nodes
 
@@ -322,6 +358,12 @@ class GAD(object):
     def extract_atomic_entity_instanceid_from_path(self, path):
         return path.split('/')[9]
 
+    def extract_entity_id_from_path(self, path):
+        return path.split('/')[7]
+
+    def extract_entity_instanceid_from_path(self, path):
+        return path.split('/')[9]
+
     def extract_fduid_from_path(self, path):
         return path.split('/')[7]
 
@@ -447,6 +489,45 @@ class GAD(object):
 
     # Catalog
 
+    def get_catalog_all_entities(self, sysid, tenantid):
+        s = self.get_catalog_all_entities_selector(sysid, tenantid)
+        res = self.ws.get(s)
+        if len(res) == 0:
+            return []
+        else:
+            xs = map(lambda x: self.extract_entity_id_from_path(x[0]), res)
+            return list(xs)
+
+    def get_catalog_entity_info(self, sysid, tenantid, eid):
+        p = self.get_catalog_entity_info_path(sysid, tenantid, eid)
+        res = self.ws.get(p)
+        if len(res) == 0:
+            return None
+        v = res[0][1]
+        return json.loads(v.get_value())
+
+    def add_catalog_entity_info(self, sysid, tenantid, eid, einfo):
+        p = self.get_catalog_entity_info_path(sysid, tenantid, eid)
+        v = Value(json.dumps(einfo), encoding=Encoding.STRING)
+        return self.ws.put(p, v)
+
+    def remove_catalog_entity_info(self, sysid, tenantid, eid):
+        p = self.get_catalog_entity_info_path(sysid, tenantid, eid)
+        self.ws.remove(p)
+
+    def observe_catalog_entities(self, sysid, tenantid, callback):
+        s = self.get_catalog_all_entities_selector(sysid, tenantid)
+        def cb(kvs):
+            if len(kvs) == 0:
+                raise ValueError('Listener received empty data')
+            else:
+                v = kvs[0][1].get_value()
+                if v is not None:
+                    callback(json.loads(v.value))
+        subid = self.ws.subscribe(s, cb)
+        self.listeners.append(subid)
+        return subid
+
     def get_catalog_all_atomic_entities(self, sysid, tenantid):
         s = self.get_catalog_all_atomic_entities_selector(sysid, tenantid)
         res = self.ws.get(s)
@@ -541,6 +622,54 @@ class GAD(object):
 
     # Records
 
+
+    def get_records_all_entities_instances(self, sysid, tenantid):
+        s = self.get_records_all_entities_instances_selector(sysid, tenantid)
+        res = self.ws.get(s)
+        if len(res) == 0:
+            return []
+        else:
+            xs = map(lambda x: (self.extract_entity_id_from_path(x[0]),self.extract_entity_instanceid_from_path(x[0])), res)
+            return list(xs)
+
+    def get_records_all_entity_instances(self, sysid, tenantid, eid):
+        s = self.get_records_all_entity_instances_selector(sysid, tenantid, eid)
+        res = self.ws.get(s)
+        if len(res) == 0:
+            return []
+        else:
+            xs = map(lambda x: self.extract_entity_instanceid_from_path(x[0]), res)
+            return list(xs)
+
+    def get_records_entity_info(self, sysid, tenantid, eid, instanceid):
+        p = self.get_records_entity_instance_info_path(sysid, tenantid, eid, instanceid)
+        res = self.ws.get(p)
+        if len(res) == 0:
+            return None
+        v = res[0][1]
+        return json.loads(v.get_value())
+
+    def add_records_entity_info(self, sysid, tenantid, eid, instanceid, aeinfo):
+        p = self.get_records_entity_instance_info_path(sysid, tenantid, eid, instanceid)
+        v = Value(json.dumps(aeinfo), encoding=Encoding.STRING)
+        return self.ws.put(p, v)
+
+    def remove_records_entity_info(self, sysid, tenantid, eid, instanceid):
+        p = self.get_records_entity_instance_info_path(sysid, tenantid, eid, instanceid)
+        self.ws.remove(p)
+
+    def observe_records_entities(self, sysid, tenantid, callback):
+        s = self.get_records_all_entities_instances_selector(sysid, tenantid)
+        def cb(kvs):
+            if len(kvs) == 0:
+                raise ValueError('Listener received empty data')
+            else:
+                v = kvs[0][1].get_value()
+                if v is not None:
+                    callback(json.loads(v.value))
+        subid = self.ws.subscribe(s, cb)
+        self.listeners.append(subid)
+        return subid
 
     def get_records_all_atomic_entities_instances(self, sysid, tenantid):
         s = self.get_records_all_atomic_entities_instances_selector(sysid, tenantid)
@@ -1125,6 +1254,46 @@ class GAD(object):
     def terminate_ae_from_node(self, sysid, tenantid, nodeid, ae_inst_id):
         fname = 'terminate_ae'
         params = {'instance_id':ae_inst_id}
+        s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
+        res = self.ws.eval(s)
+        if len(res) == 0:
+            raise ValueError('Empty data on exec_agent_eval')
+        else:
+            return json.loads(res[0][1].get_value())
+
+    def onboard_entity_from_node(self, sysid, tenantid, nodeid, e_info):
+        fname = 'onboard_entity'
+        params = {'descriptor':e_info}
+        s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
+        res = self.ws.eval(s)
+        if len(res) == 0:
+            raise ValueError('Empty data on exec_agent_eval')
+        else:
+            return json.loads(res[0][1].get_value())
+
+    def instantiate_entity_from_node(self, sysid, tenantid, nodeid, e_id):
+        fname = 'instantiate_entity'
+        params = {'entity_id':e_id}
+        s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
+        res = self.ws.eval(s)
+        if len(res) == 0:
+            raise ValueError('Empty data on exec_agent_eval')
+        else:
+            return json.loads(res[0][1].get_value())
+
+    def offload_entity_from_node(self, sysid, tenantid, nodeid, e_id):
+        fname = 'offload_entity'
+        params = {'entity_id':e_id}
+        s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
+        res = self.ws.eval(s)
+        if len(res) == 0:
+            raise ValueError('Empty data on exec_agent_eval')
+        else:
+            return json.loads(res[0][1].get_value())
+
+    def terminate_entity_from_node(self, sysid, tenantid, nodeid, e_inst_id):
+        fname = 'terminate_entity'
+        params = {'instance_id':e_inst_id}
         s = self.get_agent_exec_path_with_params(sysid, tenantid, nodeid, fname, params)
         res = self.ws.eval(s)
         if len(res) == 0:

--- a/src/core/ocaml/fos-core/yaks_connector.ml
+++ b/src/core/ocaml/fos-core/yaks_connector.ml
@@ -134,7 +134,6 @@ module MakeGAD(P: sig val prefix: string end) = struct
   let get_catalog_all_fdu_selector sysid tenantid =
     create_selector [P.prefix; sysid; "tenants"; tenantid; "catalog"; "fdu"; "*"; "info"]
 
-
   let get_catalog_entity_info_path sysid tenantid eid =
     create_path [P.prefix; sysid; "tenants"; tenantid; "catalog"; "entities"; eid; "info"]
 

--- a/src/core/ocaml/fos-core/yaks_connector.ml
+++ b/src/core/ocaml/fos-core/yaks_connector.ml
@@ -1513,6 +1513,50 @@ module MakeGAD(P: sig val prefix: string end) = struct
     | (_,v)::_ ->
       Lwt.return (Agent_types.eval_result_of_string (Yaks.Value.to_string v))
 
+  let onboard_entity_from_node sysid tenantid nodeid ae_info connector =
+    MVar.read connector >>= fun connector ->
+    let fname = "onboard_entity" in
+    let params = [("descriptor",User.Descriptors.Entity.string_of_descriptor ae_info)] in
+    let s = get_agent_exec_path_with_params sysid tenantid nodeid fname params in
+    let%lwt res = Yaks.Workspace.eval s connector.ws in
+    match res with
+    | [] ->  Lwt.fail @@ FException (`InternalError (`Msg ("Empty value for agent_eval") ))
+    | (_,v)::_ ->
+      Lwt.return (Agent_types.eval_result_of_string (Yaks.Value.to_string v))
+
+  let instantiate_entity_from_node sysid tenantid nodeid ae_id connector =
+    MVar.read connector >>= fun connector ->
+    let fname = "instantiate_entity" in
+    let params = [("entity_id",ae_id)] in
+    let s = get_agent_exec_path_with_params sysid tenantid nodeid fname params in
+    let%lwt res = Yaks.Workspace.eval s connector.ws in
+    match res with
+    | [] ->  Lwt.fail @@ FException (`InternalError (`Msg ("Empty value for agent_eval") ))
+    | (_,v)::_ ->
+      Lwt.return (Agent_types.eval_result_of_string (Yaks.Value.to_string v))
+
+  let offload_entity_from_node sysid tenantid nodeid ae_id connector =
+    MVar.read connector >>= fun connector ->
+    let fname = "offload_entity" in
+    let params = [("entity_id",ae_id)] in
+    let s = get_agent_exec_path_with_params sysid tenantid nodeid fname params in
+    let%lwt res = Yaks.Workspace.eval s connector.ws in
+    match res with
+    | [] ->  Lwt.fail @@ FException (`InternalError (`Msg ("Empty value for agent_eval") ))
+    | (_,v)::_ ->
+      Lwt.return (Agent_types.eval_result_of_string (Yaks.Value.to_string v))
+
+  let terminate_entity_from_node sysid tenantid nodeid ae_inst_id connector =
+    MVar.read connector >>= fun connector ->
+    let fname = "terminate_entity" in
+    let params = [("instance_id",ae_inst_id)] in
+    let s = get_agent_exec_path_with_params sysid tenantid nodeid fname params in
+    let%lwt res = Yaks.Workspace.eval s connector.ws in
+    match res with
+    | [] ->  Lwt.fail @@ FException (`InternalError (`Msg ("Empty value for agent_eval") ))
+    | (_,v)::_ ->
+      Lwt.return (Agent_types.eval_result_of_string (Yaks.Value.to_string v))
+
 
 end
 

--- a/src/core/ocaml/fos-core/yaks_connector.ml
+++ b/src/core/ocaml/fos-core/yaks_connector.ml
@@ -933,7 +933,11 @@ module MakeGAD(P: sig val prefix: string end) = struct
 
   let get_node_fdu_info sysid tenantid nodeid fduid instanceid connector =
     MVar.read connector >>= fun connector ->
-    let s = Yaks.Selector.of_path @@ get_node_fdu_info_path sysid tenantid nodeid fduid instanceid in
+    let s =
+      match fduid with
+      | "*" -> get_node_fdu_instance_selector sysid tenantid nodeid instanceid
+      | _ -> Yaks.Selector.of_path @@ get_node_fdu_info_path sysid tenantid nodeid fduid instanceid
+    in
     Yaks.Workspace.get s connector.ws
     >>= fun kvs ->
     match kvs with
@@ -957,7 +961,7 @@ module MakeGAD(P: sig val prefix: string end) = struct
 
   let get_fdu_nodes sysid tenantid fduid connector =
     MVar.read connector >>= fun connector ->
-    let s = Yaks.Selector.of_path @@ get_node_fdu_info_path sysid tenantid "*" fduid "*" in
+    let s = get_node_fdu_instances_selector sysid tenantid "*" fduid in
     Yaks.Workspace.get s connector.ws
     >>= fun kvs ->
     match kvs with
@@ -2534,3 +2538,4 @@ module LocalConstraint = struct
 
 
 end
+

--- a/src/im/ocaml/Makefile
+++ b/src/im/ocaml/Makefile
@@ -15,12 +15,17 @@ atd:
 
 	atdgen -j-std fos-im/base_fdu.atd
 	atdgen -j-std fos-im/base_atomic_entity.atd
+	atdgen -j-std fos-im/base_entity.atd
 
 	atdgen -j-std fos-im/user_fdu.atd
 	atdgen -j-std fos-im/user_atomic_entity.atd
+	atdgen -j-std fos-im/user_entity.atd
 
 	atdgen -j-std fos-im/infra_fdu.atd
 	atdgen -j-std fos-im/infra_atomic_entity.atd
+	atdgen -j-std fos-im/infra_entity.atd
+
+
 
 
 	atdgen -j-std fos-im/nfv.atd
@@ -38,12 +43,15 @@ clean:
 
 	rm -rf fos-im/base_fdu*.ml*
 	rm -rf fos-im/base_atomic_entity*.ml*
+	rm -rf fos-im/base_entity*.ml*
 
 	rm -rf fos-im/user_fdu*.ml*
 	rm -rf fos-im/user_atomic_entity*.ml*
+	rm -rf fos-im/user_entity*.ml*
 
 	rm -rf fos-im/infra_fdu*.ml*
 	rm -rf fos-im/infra_atomic_entity*.ml*
+	rm -rf fos-im/infra_entity*.ml*
 
 	rm -rf fos-im/nfv*.ml*
 	rm -rf fos-im/mec*.ml*

--- a/src/im/ocaml/Makefile
+++ b/src/im/ocaml/Makefile
@@ -13,6 +13,11 @@ atd:
 
 	atdgen -j-std fos-im/router.atd
 
+
+	atdgen -j-std fos-im/base_network.atd
+	atdgen -j-std fos-im/user_network.atd
+	atdgen -j-std fos-im/infra_network.atd
+
 	atdgen -j-std fos-im/base_fdu.atd
 	atdgen -j-std fos-im/base_atomic_entity.atd
 	atdgen -j-std fos-im/base_entity.atd
@@ -52,6 +57,8 @@ clean:
 	rm -rf fos-im/infra_fdu*.ml*
 	rm -rf fos-im/infra_atomic_entity*.ml*
 	rm -rf fos-im/infra_entity*.ml*
+
+	rm -rf fos-im/*_network*.ml*
 
 	rm -rf fos-im/nfv*.ml*
 	rm -rf fos-im/mec*.ml*

--- a/src/im/ocaml/fos-im/agent_types.atd
+++ b/src/im/ocaml/fos-im/agent_types.atd
@@ -55,6 +55,7 @@ type plugin_loader_item = {
 type eval_result = {
   ?result : json option;
   ?error : int option;
+  ?error_msg : string option;
 }
 
 

--- a/src/im/ocaml/fos-im/base_entity.atd
+++ b/src/im/ocaml/fos-im/base_entity.atd
@@ -1,0 +1,53 @@
+(*********************************************************************************
+ * Copyright (c) 2018 ADLINK Technology Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ * Contributors: 1
+ *   Gabriele Baldoni (gabriele (dot) baldoni (at) adlinktech (dot) com ) - IM Update
+ *********************************************************************************)
+(* Atomic Entity Shared Types *)
+
+type json <ocaml module="Abs_json"> = abstract
+
+
+
+(* CPD as ETSI NFV *)
+
+type cp_kind = [
+  | VPORT
+]
+
+type connection_point_descriptor = {
+  uuid : string;
+  cp_id : string;
+  ?cp_type : cp_kind option;
+  ?port_security_enabled: bool option;
+  ?atomic_vld_ref : string option;
+}
+
+(* VLD as ETSI NFV *)
+
+type vl_kind = [
+  | ELINE
+  | ELAN
+]
+
+
+type ip_kind = [
+  | IPV4
+  | IPV6
+]
+
+type address_information = {
+  ip_version : ip_kind;
+  subnet : string;   (*  X.X.X.X/Y*)
+  ?gateway : string option; (* X.X.X.X *)
+  dhcp_enable :  bool;
+  ?dhcp_range : string option; (* X.X.X.X,X.X.X.Z *)
+  ?dns : string option; (* X.X.X.X,X.X.X.Z,.... *)
+}

--- a/src/im/ocaml/fos-im/base_entity.atd
+++ b/src/im/ocaml/fos-im/base_entity.atd
@@ -22,13 +22,6 @@ type cp_kind = [
   | VPORT
 ]
 
-type connection_point_descriptor = {
-  uuid : string;
-  cp_id : string;
-  ?cp_type : cp_kind option;
-  ?port_security_enabled: bool option;
-  ?atomic_vld_ref : string option;
-}
 
 (* VLD as ETSI NFV *)
 

--- a/src/im/ocaml/fos-im/base_fdu.atd
+++ b/src/im/ocaml/fos-im/base_fdu.atd
@@ -143,10 +143,3 @@ type storage_kind = [
   | FILE
   | OBJECT
 ]
-
-
-(* CPD as ETSI NFV *)
-
-type cp_kind = [
-  | VPORT
-]

--- a/src/im/ocaml/fos-im/base_network.atd
+++ b/src/im/ocaml/fos-im/base_network.atd
@@ -10,7 +10,7 @@
  * Contributors: 1
  *   Gabriele Baldoni (gabriele (dot) baldoni (at) adlinktech (dot) com ) - IM Update
  *********************************************************************************)
-(* Atomic Entity Shared Types *)
+(* Network Shared Types *)
 
 type json <ocaml module="Abs_json"> = abstract
 

--- a/src/im/ocaml/fos-im/fos_errors.ml
+++ b/src/im/ocaml/fos-im/fos_errors.ml
@@ -1,8 +1,12 @@
-type error_info = [`NoMsg | `Msg of string | `Code of int | `Pos of (string * int * int * int) | `Loc of string] [@@deriving show]
+type error_info = [`NoMsg | `Msg of string | `Code of int | `Pos of (string * int * int * int) | `Loc of string | `MsgCode of (string * int)] [@@deriving show]
 
 type ferror = [
   | `InternalError of error_info
   | `InformationModelError of error_info
+  | `NotFound of error_info
+  | `NotAuthorized of error_info
+  | `PluginNotFound of error_info
+  | `NoCompatibleNodes of error_info
 ] [@@deriving show]
 
 

--- a/src/im/ocaml/fos-im/fos_im.ml
+++ b/src/im/ocaml/fos-im/fos_im.ml
@@ -47,6 +47,7 @@ module Base = struct
     module FDU = Base_fdu
     module AtomicEnitity = Base_atomic_entity
     module Entity = Base_entity
+    module Network = Base_network
   end
 end
 
@@ -55,6 +56,7 @@ module User  = struct
     module FDU = User_fdu
     module AtomicEntity = User_atomic_entity
     module Entity = User_entity
+    module Network = User_network
   end
 end
 
@@ -64,6 +66,7 @@ module Infra = struct
     module FDU = Infra_fdu
     module AtomicEntity = Infra_atomic_entity
     module Entity = Infra_entity
+    module Network = Infra_network
   end
 end
 

--- a/src/im/ocaml/fos-im/fos_im.ml
+++ b/src/im/ocaml/fos-im/fos_im.ml
@@ -46,6 +46,7 @@ module Base = struct
   module Descriptors = struct
     module FDU = Base_fdu
     module AtomicEnitity = Base_atomic_entity
+    module Entity = Base_entity
   end
 end
 
@@ -53,6 +54,7 @@ module User  = struct
   module Descriptors = struct
     module FDU = User_fdu
     module AtomicEntity = User_atomic_entity
+    module Entity = User_entity
   end
 end
 
@@ -61,6 +63,7 @@ module Infra = struct
     module Router = Router
     module FDU = Infra_fdu
     module AtomicEntity = Infra_atomic_entity
+    module Entity = Infra_entity
   end
 end
 

--- a/src/im/ocaml/fos-im/infra_atomic_entity.atd
+++ b/src/im/ocaml/fos-im/infra_atomic_entity.atd
@@ -17,9 +17,10 @@ type json <ocaml module="Abs_json"> = abstract
 
 type fdu <ocaml module="Infra_fdu"> = abstract
 
-type cp_kind <ocaml module="Base_atomic_entity"> = abstract
-type vl_kind <ocaml module="Base_atomic_entity"> = abstract
-type address_information <ocaml module="Base_atomic_entity"> = abstract
+
+type vl_kind <ocaml module="Base_network"> = abstract
+type address_information <ocaml module="Base_network"> = abstract
+type connection_point_record <ocaml module="Infra_network"> = abstract
 
 (* Descriptor Related Types *)
 
@@ -32,14 +33,6 @@ type record = {
   depends_on : string list;
 }
 
-(* CPD as ETSI NFV *)
-
-type connection_point_record = {
-  uuid : string;
-  cp_id : string;
-  ?cp_type : cp_kind option;
-  ?port_security_enabled: bool option;
-}
 
 (* VLD as ETSI NFV *)
 

--- a/src/im/ocaml/fos-im/infra_entity.atd
+++ b/src/im/ocaml/fos-im/infra_entity.atd
@@ -1,0 +1,60 @@
+(*********************************************************************************
+ * Copyright (c) 2018 ADLINK Technology Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ * Contributors: 1
+ *   Gabriele Baldoni (gabriele (dot) baldoni (at) adlinktech (dot) com ) - IM Update
+ *********************************************************************************)
+
+(* Atomic Entity Infrastructure Information *)
+
+type cp_kind <ocaml module="Base_entity"> = abstract
+type vl_kind <ocaml module="Base_entity"> = abstract
+type address_information <ocaml module="Base_entity"> = abstract
+
+(* Descriptor Related Types *)
+
+type record = {
+  uuid : string;
+  atomic_entities : string list;
+  entity_id : string;
+  virtual_links : virtual_link_record list;
+  connection_points : connection_point_record list;
+  depends_on : string list;
+}
+
+(* CPD as ETSI NFV *)
+
+type connection_point_record = {
+  uuid : string;
+  cp_id : string;
+  ?cp_type : cp_kind option;
+  ?port_security_enabled: bool option;
+  ?require_floating_ip : bool option;
+  ?atomic_entity_cp_ref : string option;
+}
+
+(* VLD as ETSI NFV *)
+
+type virtual_link_record = {
+  uuid : string;
+  internal_vl_id : string;
+  is_mgmt : bool;
+  ?vl_type : vl_kind option;
+  ?root_bandwidth : int option;
+  ?leaf_bandwidth : int option;
+  cps : string list;
+  (* From fog05 *)
+  ?ip_configuration : address_information option;
+  (* filled by Orchestrator *)
+  ?overlay : bool option;
+  ?vni: int option;
+  ?mcast_addr: string option;
+  ?vlan_id : int option;
+  ?face : string option;
+}

--- a/src/im/ocaml/fos-im/infra_entity.atd
+++ b/src/im/ocaml/fos-im/infra_entity.atd
@@ -42,7 +42,7 @@ type connection_point_record = {
 
 type virtual_link_record = {
   uuid : string;
-  internal_vl_id : string;
+  vl_id : string;
   is_mgmt : bool;
   ?vl_type : vl_kind option;
   ?root_bandwidth : int option;

--- a/src/im/ocaml/fos-im/infra_entity.atd
+++ b/src/im/ocaml/fos-im/infra_entity.atd
@@ -13,30 +13,36 @@
 
 (* Atomic Entity Infrastructure Information *)
 
-type cp_kind <ocaml module="Base_entity"> = abstract
-type vl_kind <ocaml module="Base_entity"> = abstract
-type address_information <ocaml module="Base_entity"> = abstract
+
+type vl_kind <ocaml module="Base_network"> = abstract
+type address_information <ocaml module="Base_network"> = abstract
 
 (* Descriptor Related Types *)
 
+
+type constituent_atomic_entity = {
+  id : string;
+  uuid : string;
+  index : int;
+}
+
 type record = {
   uuid : string;
-  atomic_entities : string list;
+  atomic_entities : constituent_atomic_entity list;
   entity_id : string;
   virtual_links : virtual_link_record list;
-  connection_points : connection_point_record list;
 }
 
-(* CPD as ETSI NFV *)
-
-type connection_point_record = {
-  uuid : string;
+type cp_ref = {
+  component_id_ref : string;
+  component_index_ref : int;
   cp_id : string;
-  ?cp_type : cp_kind option;
-  ?port_security_enabled: bool option;
-  ?require_floating_ip : bool option;
-  ?atomic_entity_cp_ref : string option;
+  uuid : string;
+  ?has_floating_ip : bool option;
+  ?floating_ip_id : string option;
+  ?floating_ip : string option;
 }
+
 
 (* VLD as ETSI NFV *)
 
@@ -47,7 +53,7 @@ type virtual_link_record = {
   ?vl_type : vl_kind option;
   ?root_bandwidth : int option;
   ?leaf_bandwidth : int option;
-  cps : string list;
+  cps : cp_ref list;
   (* From fog05 *)
   ?ip_configuration : address_information option;
   (* filled by Orchestrator *)

--- a/src/im/ocaml/fos-im/infra_entity.atd
+++ b/src/im/ocaml/fos-im/infra_entity.atd
@@ -25,7 +25,6 @@ type record = {
   entity_id : string;
   virtual_links : virtual_link_record list;
   connection_points : connection_point_record list;
-  depends_on : string list;
 }
 
 (* CPD as ETSI NFV *)

--- a/src/im/ocaml/fos-im/infra_fdu.atd
+++ b/src/im/ocaml/fos-im/infra_fdu.atd
@@ -31,7 +31,8 @@ type vintf_t <ocaml module="Base_fdu"> = abstract
 type io_kind <ocaml module="Base_fdu"> = abstract
 type io_port <ocaml module="Base_fdu"> = abstract
 type storage_kind <ocaml module="Base_fdu"> = abstract
-type cp_kind <ocaml module="Base_fdu"> = abstract
+type net_state <ocaml module="Infra_network"> = abstract
+type connection_point_record <ocaml module="Infra_network"> = abstract
 
 
 (* Record Related Types *)
@@ -88,23 +89,6 @@ type storage_record = {
 }
 
 
-
-(* CPD as ETSI NFV *)
-
-type connection_point_record = {
-  uuid : string;
-  status : net_state;
-  cp_id : string;
-  ?cp_type : cp_kind option;
-  ?port_security_enabled: bool option;
-  ?internal_vld_ref : string option;
-
-  ?veth_face_name : string option;
-  ?br_name : string option;
-  ?properties : json option;
-}
-
-
 type fdu_state = [
   | DEFINE
   | CONFIGURE
@@ -138,13 +122,6 @@ type error_code = [
   | UNDEFINE_ERROR of 0
 ]
 *)
-
-type net_state = [
-  | CREATE
-  | CONNECTED
-  | DISCONNECTED
-  | DESTROY
-]
 
 
 type migration_properties = {

--- a/src/im/ocaml/fos-im/infra_network.atd
+++ b/src/im/ocaml/fos-im/infra_network.atd
@@ -10,36 +10,29 @@
  * Contributors: 1
  *   Gabriele Baldoni (gabriele (dot) baldoni (at) adlinktech (dot) com ) - IM Update
  *********************************************************************************)
-(* Atomic Entity Shared Types *)
+(* Network Descriptor Shared Types *)
 
 type json <ocaml module="Abs_json"> = abstract
+type cp_kind <ocaml module="Base_network"> = abstract
+type vl_kind <ocaml module="Base_network"> = abstract
+type address_information <ocaml module="Base_network"> = abstract
 
-
-
-(* CPD as ETSI NFV *)
-
-type cp_kind = [
-  | VPORT
-]
-
-(* VLD as ETSI NFV *)
-
-type vl_kind = [
-  | ELINE
-  | ELAN
+type net_state = [
+  | CREATE
+  | CONNECTED
+  | DISCONNECTED
+  | DESTROY
 ]
 
 
-type ip_kind = [
-  | IPV4
-  | IPV6
-]
-
-type address_information = {
-  ip_version : ip_kind;
-  subnet : string;   (*  X.X.X.X/Y*)
-  ?gateway : string option; (* X.X.X.X *)
-  dhcp_enable :  bool;
-  ?dhcp_range : string option; (* X.X.X.X,X.X.X.Z *)
-  ?dns : string option; (* X.X.X.X,X.X.X.Z,.... *)
+type connection_point_record = {
+  uuid : string;
+  cp_id : string;
+  ?cp_type : cp_kind option;
+  ?vld_ref : string option;
+  ?port_security_enabled: bool option;
+  ?veth_face_name : string option;
+  ?br_name : string option;
+  ?properties : json option;
+  status : net_state
 }

--- a/src/im/ocaml/fos-im/user_atomic_entity.atd
+++ b/src/im/ocaml/fos-im/user_atomic_entity.atd
@@ -16,9 +16,9 @@ type json <ocaml module="Abs_json"> = abstract
 
 type fdu <ocaml module="User_fdu"> = abstract
 
-type cp_kind <ocaml module="Base_atomic_entity"> = abstract
-type vl_kind <ocaml module="Base_atomic_entity"> = abstract
-type address_information <ocaml module="Base_atomic_entity"> = abstract
+type vl_kind <ocaml module="Base_network"> = abstract
+type address_information <ocaml module="Base_network"> = abstract
+type connection_point_descriptor <ocaml module="User_network"> = abstract
 
 (* Descriptor Related Types *)
 
@@ -31,17 +31,6 @@ type descriptor = {
   internal_virtual_links : internal_virtual_link_descriptor list;
   connection_points : connection_point_descriptor list;
   depends_on : string list;
-}
-
-(* CPD as ETSI NFV *)
-
-type connection_point_descriptor = {
-  name : string;
-  id : string;
-  ?short_name : string option;
-  ?cp_type : cp_kind option;
-  ?port_security_enabled: bool option;
-
 }
 
 (* VLD as ETSI NFV *)

--- a/src/im/ocaml/fos-im/user_entity.atd
+++ b/src/im/ocaml/fos-im/user_entity.atd
@@ -1,0 +1,58 @@
+(*********************************************************************************
+ * Copyright (c) 2018 ADLINK Technology Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ * Contributors: 1
+ *   Gabriele Baldoni (gabriele (dot) baldoni (at) adlinktech (dot) com ) - IM Updates
+ *********************************************************************************)
+(* AtomicEntity Manifest *)
+
+type cp_kind <ocaml module="Base_entity"> = abstract
+type vl_kind <ocaml module="Base_entity"> = abstract
+type address_information <ocaml module="Base_entity"> = abstract
+
+(* Descriptor Related Types *)
+
+type descriptor = {
+  ?uuid : string option;
+  id : string;
+  name : string;
+  ?description : string option;
+  ?version : string option;
+  atomic_entities : string list;
+  virtual_links : virtual_link_descriptor list;
+  connection_points : connection_point_descriptor list;
+}
+
+(* CPD as ETSI NFV *)
+
+type connection_point_descriptor = {
+  name : string;
+  id : string;
+  ?short_name : string option;
+  ?cp_type : cp_kind option;
+  ?port_security_enabled: bool option;
+  ?require_floating_ip : bool option;
+  ?atomic_entity_cp_ref : string option;
+}
+
+(* VLD as ETSI NFV *)
+
+type virtual_link_descriptor = {
+  id : string;
+  name : string;
+  is_mgmt : bool;
+  ?short_name : string option;
+  ?description : string option;
+  ?vl_type : vl_kind option;
+  ?root_bandwidth : int option;
+  ?leaf_bandwidth : int option;
+  cps : string list;
+  (* From fog05 *)
+  ?ip_configuration : address_information option;
+}

--- a/src/im/ocaml/fos-im/user_entity.atd
+++ b/src/im/ocaml/fos-im/user_entity.atd
@@ -12,11 +12,16 @@
  *********************************************************************************)
 (* AtomicEntity Manifest *)
 
-type cp_kind <ocaml module="Base_entity"> = abstract
-type vl_kind <ocaml module="Base_entity"> = abstract
-type address_information <ocaml module="Base_entity"> = abstract
+type vl_kind <ocaml module="Base_network"> = abstract
+type address_information <ocaml module="Base_network"> = abstract
 
 (* Descriptor Related Types *)
+
+
+type constituent_atomic_entity = {
+  id : string;
+  index : int;
+}
 
 type descriptor = {
   ?uuid : string option;
@@ -24,24 +29,16 @@ type descriptor = {
   name : string;
   ?description : string option;
   ?version : string option;
-  atomic_entities : string list;
+  atomic_entities : constituent_atomic_entity list;
   virtual_links : virtual_link_descriptor list;
-  connection_points : connection_point_descriptor list;
 }
 
-(* CPD as ETSI NFV *)
-
-type connection_point_descriptor = {
-  name : string;
-  id : string;
-  ?short_name : string option;
-  ?cp_type : cp_kind option;
-  ?port_security_enabled: bool option;
-  ?require_floating_ip : bool option;
-  ?atomic_entity_cp_ref : string option;
+type cp_ref = {
+  component_id_ref : string;
+  component_index_ref : int;
+  cp_id : string;
+  ?has_floating_ip : bool option;
 }
-
-(* VLD as ETSI NFV *)
 
 type virtual_link_descriptor = {
   id : string;
@@ -52,7 +49,7 @@ type virtual_link_descriptor = {
   ?vl_type : vl_kind option;
   ?root_bandwidth : int option;
   ?leaf_bandwidth : int option;
-  cps : string list;
+  cps : cp_ref list;
   (* From fog05 *)
   ?ip_configuration : address_information option;
 }

--- a/src/im/ocaml/fos-im/user_fdu.atd
+++ b/src/im/ocaml/fos-im/user_fdu.atd
@@ -31,7 +31,7 @@ type vintf_t <ocaml module="Base_fdu"> = abstract
 type io_kind <ocaml module="Base_fdu"> = abstract
 type io_port <ocaml module="Base_fdu"> = abstract
 type storage_kind <ocaml module="Base_fdu"> = abstract
-type cp_kind <ocaml module="Base_fdu"> = abstract
+type connection_point_descriptor <ocaml module="User_network"> = abstract
 
 (* Descriptor Related Types *)
 
@@ -75,21 +75,3 @@ type storage_descriptor = {
   ?file_system_protocol : string option; (* only in case of FILE storage *)
   ?cp_id : string option; (* only in case of FILE storage *)
 }
-
-
-(* CPD as ETSI NFV *)
-
-type connection_point_descriptor = {
-  name : string;
-  id : string;
-  ?short_name : string option;
-  ?cp_type : cp_kind option;
-  ?port_security_enabled: bool option;
-  ?internal_vld_ref : string option;
-}
-
-
-
-
-
-

--- a/src/im/ocaml/fos-im/user_network.atd
+++ b/src/im/ocaml/fos-im/user_network.atd
@@ -10,36 +10,22 @@
  * Contributors: 1
  *   Gabriele Baldoni (gabriele (dot) baldoni (at) adlinktech (dot) com ) - IM Update
  *********************************************************************************)
-(* Atomic Entity Shared Types *)
+(* Network Descriptor Shared Types *)
 
 type json <ocaml module="Abs_json"> = abstract
+type cp_kind <ocaml module="Base_network"> = abstract
+type vl_kind <ocaml module="Base_network"> = abstract
+type address_information <ocaml module="Base_network"> = abstract
 
 
 
-(* CPD as ETSI NFV *)
 
-type cp_kind = [
-  | VPORT
-]
-
-(* VLD as ETSI NFV *)
-
-type vl_kind = [
-  | ELINE
-  | ELAN
-]
-
-
-type ip_kind = [
-  | IPV4
-  | IPV6
-]
-
-type address_information = {
-  ip_version : ip_kind;
-  subnet : string;   (*  X.X.X.X/Y*)
-  ?gateway : string option; (* X.X.X.X *)
-  dhcp_enable :  bool;
-  ?dhcp_range : string option; (* X.X.X.X,X.X.X.Z *)
-  ?dns : string option; (* X.X.X.X,X.X.X.Z,.... *)
+type connection_point_descriptor = {
+  ?uuid : string option;
+  name : string;
+  id : string;
+  ?vld_ref : string option;
+  ?short_name : string option;
+  ?cp_type : cp_kind option;
+  ?port_security_enabled: bool option;
 }

--- a/src/im/python/Makefile
+++ b/src/im/python/Makefile
@@ -20,8 +20,8 @@ PYANG:= pyang
 PYBINDPLUGIN:=$(shell /usr/bin/env python3 -c \
 	            'import pyangbind; import os; print("{}/plugin".format(os.path.dirname(pyangbind.__file__)))')
 
-YANG_DESC_MODELS := user_fdu
-YANG_RECORD_MODELS := infra_fdu
+YANG_DESC_MODELS := user_fdu user_atomic_entity user_entity
+YANG_RECORD_MODELS := infra_fdu infra_atomic_entity infra_entity
 
 PYTHON_MODELS := $(addsuffix .py, $(YANG_DESC_MODELS))
 PYTHON_RECORDS := $(addsuffix .py, $(YANG_RECORD_MODELS))

--- a/src/im/python/yang/fos/infra_atomic_entity.yang
+++ b/src/im/python/yang/fos/infra_atomic_entity.yang
@@ -170,7 +170,7 @@ module infra_atomic_entity {
 
         list connection_points {
             key "uuid";
-            uses connection_point_record;
+            uses connection_point;
         }
 
         leaf-list depends_on {

--- a/src/im/python/yang/fos/infra_atomic_entity.yang
+++ b/src/im/python/yang/fos/infra_atomic_entity.yang
@@ -1,0 +1,161 @@
+module infra_atomic_entity {
+    namespace "urn:fog05:im:infra:atomicentity";
+    prefix "atomicentityr";
+
+    import infra_fdu {
+        prefix "infra_fdu";
+    }
+
+    typedef cp_kind {
+        type enumeration {
+            enum VPORT;
+        }
+    }
+
+    typedef vl_kind {
+        type enumeration {
+            enum ELINE;
+            enum ELAN;
+        }
+    }
+
+    typedef ip_kind {
+        type enumeration {
+            enum IPV4;
+            enum IPV6;
+        }
+    }
+
+    grouping address_information {
+
+        leaf ip_version {
+            type ip_kind;
+        }
+
+        leaf subnet {
+            type string;
+        }
+
+        leaf gateway {
+            type string;
+        }
+
+        leaf checksum {
+            description
+              "SHA1 checksum of the image file";
+            type string;
+        }
+
+        leaf dhcp_enable {
+            type boolean;
+        }
+
+        leaf dhcp_range {
+            type string;
+        }
+
+        leaf-list dns {
+            type string;
+        }
+    }
+    grouping connection_point_record {
+        leaf uuid {
+            type string;
+        }
+
+        leaf cp_id {
+            type string;
+        }
+
+        leaf cp_type {
+            type cp_kind;
+        }
+
+        leaf port_security_enabled {
+            type boolean;
+        }
+    }
+
+    grouping internal_virtual_link_record {
+        leaf uuid {
+            type string;
+        }
+
+        leaf internal_vl_id {
+            type string;
+        }
+
+        leaf is_mgmt {
+            type boolean;
+        }
+
+        leaf vl_type {
+            type vl_kind;
+        }
+
+        leaf root_bandwidth {
+            type int64;
+        }
+
+        leaf leaf_bandwidth {
+            type int64;
+        }
+
+        leaf-list int_cps {
+            type string;
+        }
+
+        container ip_configuration {
+            uses address_information;
+        }
+
+        leaf overlay {
+            type boolean;
+        }
+
+        leaf vni {
+            type string;
+        }
+
+        leaf vlan_id {
+            type string;
+        }
+
+        leaf face {
+            type string;
+        }
+    }
+
+    grouping record {
+        leaf uuid {
+            type string;
+        }
+
+        leaf atomic_entity_id {
+            type string;
+        }
+
+        list fdus {
+            key "uuid";
+            uses infra_fdu:record;
+        }
+
+        list internal_virtual_links {
+            key "uuid";
+            uses internal_virtual_link_record;
+        }
+
+        list connection_points {
+            key "uuid";
+            uses connection_point_record;
+        }
+
+        leaf-list depends_on {
+            type string;
+        }
+    }
+
+    container ae_record {
+        uses record;
+    }
+}

--- a/src/im/python/yang/fos/infra_atomic_entity.yang
+++ b/src/im/python/yang/fos/infra_atomic_entity.yang
@@ -58,7 +58,8 @@ module infra_atomic_entity {
             type string;
         }
     }
-    grouping connection_point_record {
+    grouping connection_point {
+
         leaf uuid {
             type string;
         }
@@ -73,6 +74,28 @@ module infra_atomic_entity {
 
         leaf port_security_enabled {
             type boolean;
+        }
+
+        leaf vld_ref {
+            description
+              "Reference to the VL this CP is connected";
+            type string;
+        }
+
+        leaf veth_face_name {
+            type string;
+        }
+
+        leaf br_name {
+            type string;
+        }
+
+        leaf properties {
+            type string;
+        }
+
+        leaf status {
+            type string;
         }
     }
 

--- a/src/im/python/yang/fos/infra_entity.yang
+++ b/src/im/python/yang/fos/infra_entity.yang
@@ -54,31 +54,6 @@ module infra_entity {
             type string;
         }
     }
-    grouping connection_point_record {
-        leaf uuid {
-            type string;
-        }
-
-        leaf cp_id {
-            type string;
-        }
-
-        leaf cp_type {
-            type cp_kind;
-        }
-
-        leaf port_security_enabled {
-            type boolean;
-        }
-
-        leaf require_floating_ip {
-            type boolean;
-        }
-
-        leaf atomic_entity_cp_ref {
-            type string;
-        }
-    }
 
     grouping virtual_link_record {
         leaf vl_id {
@@ -146,11 +121,6 @@ module infra_entity {
         list virtual_links {
             key "uuid";
             uses virtual_link_record;
-        }
-
-        list connection_points {
-            key "uuid";
-            uses connection_point_record;
         }
     }
 

--- a/src/im/python/yang/fos/infra_entity.yang
+++ b/src/im/python/yang/fos/infra_entity.yang
@@ -1,0 +1,160 @@
+module infra_entity {
+    namespace "urn:fog05:im:infra:entity";
+    prefix "entityr";
+
+    typedef cp_kind {
+        type enumeration {
+            enum VPORT;
+        }
+    }
+
+    typedef vl_kind {
+        type enumeration {
+            enum ELINE;
+            enum ELAN;
+        }
+    }
+
+    typedef ip_kind {
+        type enumeration {
+            enum IPV4;
+            enum IPV6;
+        }
+    }
+
+    grouping address_information {
+
+        leaf ip_version {
+            type ip_kind;
+        }
+
+        leaf subnet {
+            type string;
+        }
+
+        leaf gateway {
+            type string;
+        }
+
+        leaf checksum {
+            description
+              "SHA1 checksum of the image file";
+            type string;
+        }
+
+        leaf dhcp_enable {
+            type boolean;
+        }
+
+        leaf dhcp_range {
+            type string;
+        }
+
+        leaf-list dns {
+            type string;
+        }
+    }
+    grouping connection_point_record {
+        leaf uuid {
+            type string;
+        }
+
+        leaf cp_id {
+            type string;
+        }
+
+        leaf cp_type {
+            type cp_kind;
+        }
+
+        leaf port_security_enabled {
+            type boolean;
+        }
+
+        leaf require_floating_ip {
+            type boolean;
+        }
+
+        leaf atomic_entity_cp_ref {
+            type string;
+        }
+    }
+
+    grouping virtual_link_record {
+        leaf id {
+            type string;
+        }
+
+        leaf uuid {
+            type string;
+        }
+
+        leaf is_mgmt {
+            type boolean;
+        }
+
+        leaf vl_type {
+            type vl_kind;
+        }
+
+        leaf root_bandwidth {
+            type int64;
+        }
+
+        leaf leaf_bandwidth {
+            type int64;
+        }
+
+        leaf-list cps {
+            type string;
+        }
+
+        container ip_configuration {
+            uses address_information;
+        }
+
+        leaf overlay {
+            type boolean;
+        }
+
+        leaf vni {
+            type string;
+        }
+
+        leaf vlan_id {
+            type string;
+        }
+
+        leaf face {
+            type string;
+        }
+    }
+
+    grouping record {
+        leaf uuid {
+            type string;
+        }
+
+        leaf entity_id {
+            type string;
+        }
+
+        leaf-list atomic_entities {
+            type string;
+        }
+
+        list virtual_links {
+            key "uuid";
+            uses virtual_link_record;
+        }
+
+        list connection_points {
+            key "uuid";
+            uses connection_point_record;
+        }
+    }
+
+    container entity_record {
+        uses record;
+    }
+}

--- a/src/im/python/yang/fos/infra_entity.yang
+++ b/src/im/python/yang/fos/infra_entity.yang
@@ -81,7 +81,7 @@ module infra_entity {
     }
 
     grouping virtual_link_record {
-        leaf id {
+        leaf vl_id {
             type string;
         }
 

--- a/src/im/python/yang/fos/infra_entity.yang
+++ b/src/im/python/yang/fos/infra_entity.yang
@@ -55,6 +55,32 @@ module infra_entity {
         }
     }
 
+    grouping cp_ref {
+        leaf component_id_ref {
+            type string;
+        }
+
+        leaf component_index_ref {
+            type int64;
+        }
+
+        leaf cp_id {
+            type string;
+        }
+
+        leaf has_floating_ip {
+            type boolean;
+        }
+
+        leaf floating_ip_id {
+            type string;
+        }
+
+        leaf floating_ip {
+            type string;
+        }
+    }
+
     grouping virtual_link_record {
         leaf vl_id {
             type string;
@@ -80,8 +106,9 @@ module infra_entity {
             type int64;
         }
 
-        leaf-list cps {
-            type string;
+        list cps {
+            key "component_index_ref";
+            uses cp_ref;
         }
 
         container ip_configuration {
@@ -105,6 +132,21 @@ module infra_entity {
         }
     }
 
+    grouping contituent_atomic_entity {
+
+        leaf uuid {
+            type string;
+        }
+
+        leaf id {
+            type string;
+        }
+
+        leaf index {
+            type int64;
+        }
+    }
+
     grouping record {
         leaf uuid {
             type string;
@@ -114,8 +156,9 @@ module infra_entity {
             type string;
         }
 
-        leaf-list atomic_entities {
-            type string;
+        list atomic_entities {
+            key "uuid";
+            uses contituent_atomic_entity;
         }
 
         list virtual_links {

--- a/src/im/python/yang/fos/infra_entity.yang
+++ b/src/im/python/yang/fos/infra_entity.yang
@@ -64,6 +64,10 @@ module infra_entity {
             type int64;
         }
 
+        leaf uuid {
+            type string;
+        }
+
         leaf cp_id {
             type string;
         }

--- a/src/im/python/yang/fos/infra_fdu.yang
+++ b/src/im/python/yang/fos/infra_fdu.yang
@@ -377,10 +377,6 @@ module infra_fdu {
             type string;
         }
 
-        leaf status {
-            type net_state;
-        }
-
         leaf cp_type {
             type cp_kind;
         }
@@ -389,13 +385,9 @@ module infra_fdu {
             type boolean;
         }
 
-        leaf internal_vld_ref {
+        leaf vld_ref {
             description
               "Reference to the VL this CP is connected";
-            type string;
-        }
-
-        leaf br_name {
             type string;
         }
 
@@ -403,11 +395,18 @@ module infra_fdu {
             type string;
         }
 
+        leaf br_name {
+            type string;
+        }
+
         leaf properties {
             type string;
         }
-    }
 
+        leaf status {
+            type string;
+        }
+    }
     grouping io_port {
         leaf name {
             description

--- a/src/im/python/yang/fos/user_atomic_entity.yang
+++ b/src/im/python/yang/fos/user_atomic_entity.yang
@@ -58,12 +58,21 @@ module user_atomic_entity {
             type string;
         }
     }
-    grouping connection_point_descriptor {
+    grouping connection_point {
+
+        leaf uuid {
+            type string;
+        }
+
         leaf name {
             type string;
         }
 
         leaf id {
+            type string;
+        }
+
+        leaf short_name {
             type string;
         }
 
@@ -73,6 +82,12 @@ module user_atomic_entity {
 
         leaf port_security_enabled {
             type boolean;
+        }
+
+        leaf vld_ref {
+            description
+              "Reference to the VL this CP is connected";
+            type string;
         }
     }
 

--- a/src/im/python/yang/fos/user_atomic_entity.yang
+++ b/src/im/python/yang/fos/user_atomic_entity.yang
@@ -162,7 +162,7 @@ module user_atomic_entity {
 
         list connection_points {
             key "id";
-            uses connection_point_descriptor;
+            uses connection_point;
         }
 
         leaf-list depends_on {

--- a/src/im/python/yang/fos/user_atomic_entity.yang
+++ b/src/im/python/yang/fos/user_atomic_entity.yang
@@ -1,0 +1,161 @@
+module user_atomic_entity {
+    namespace "urn:fog05:im:user:atomicentity";
+    prefix "atomicentityd";
+
+    import user_fdu {
+        prefix "user_fdu";
+    }
+
+    typedef cp_kind {
+        type enumeration {
+            enum VPORT;
+        }
+    }
+
+    typedef vl_kind {
+        type enumeration {
+            enum ELINE;
+            enum ELAN;
+        }
+    }
+
+    typedef ip_kind {
+        type enumeration {
+            enum IPV4;
+            enum IPV6;
+        }
+    }
+
+    grouping address_information {
+
+        leaf ip_version {
+            type ip_kind;
+        }
+
+        leaf subnet {
+            type string;
+        }
+
+        leaf gateway {
+            type string;
+        }
+
+        leaf checksum {
+            description
+              "SHA1 checksum of the image file";
+            type string;
+        }
+
+        leaf dhcp_enable {
+            type boolean;
+        }
+
+        leaf dhcp_range {
+            type string;
+        }
+
+        leaf-list dns {
+            type string;
+        }
+    }
+    grouping connection_point_descriptor {
+        leaf name {
+            type string;
+        }
+
+        leaf id {
+            type string;
+        }
+
+        leaf cp_type {
+            type cp_kind;
+        }
+
+        leaf port_security_enabled {
+            type boolean;
+        }
+    }
+
+    grouping internal_virtual_link_descriptor {
+        leaf id {
+            type string;
+        }
+
+        leaf name {
+            type string;
+        }
+
+        leaf is_mgmt {
+            type boolean;
+        }
+
+        leaf short_name {
+            type string;
+        }
+
+        leaf description {
+            type string;
+        }
+
+        leaf vl_type {
+            type vl_kind;
+        }
+
+        leaf root_bandwidth {
+            type int64;
+        }
+
+        leaf leaf_bandwidth {
+            type int64;
+        }
+
+        leaf-list int_cps {
+            type string;
+        }
+
+        container ip_configuration {
+            uses address_information;
+        }
+    }
+
+    grouping descriptor {
+        leaf uuid {
+            type string;
+        }
+
+        leaf id {
+            type string;
+        }
+
+        leaf name {
+            type string;
+        }
+
+        leaf description {
+            type string;
+        }
+
+        list fdus {
+            key "id";
+            uses user_fdu:descriptor;
+        }
+
+        list internal_virtual_links {
+            key "id";
+            uses internal_virtual_link_descriptor;
+        }
+
+        list connection_points {
+            key "id";
+            uses connection_point_descriptor;
+        }
+
+        leaf-list depends_on {
+            type string;
+        }
+    }
+
+    container ae_descriptor {
+        uses descriptor;
+    }
+}

--- a/src/im/python/yang/fos/user_entity.yang
+++ b/src/im/python/yang/fos/user_entity.yang
@@ -131,6 +131,10 @@ module user_entity {
             type string;
         }
 
+        leaf name {
+            type string;
+        }
+
         leaf description {
             type string;
         }

--- a/src/im/python/yang/fos/user_entity.yang
+++ b/src/im/python/yang/fos/user_entity.yang
@@ -1,0 +1,160 @@
+module user_entity {
+    namespace "urn:fog05:im:user:entity";
+    prefix "entityd";
+
+    typedef cp_kind {
+        type enumeration {
+            enum VPORT;
+        }
+    }
+
+    typedef vl_kind {
+        type enumeration {
+            enum ELINE;
+            enum ELAN;
+        }
+    }
+
+    typedef ip_kind {
+        type enumeration {
+            enum IPV4;
+            enum IPV6;
+        }
+    }
+
+    grouping address_information {
+
+        leaf ip_version {
+            type ip_kind;
+        }
+
+        leaf subnet {
+            type string;
+        }
+
+        leaf gateway {
+            type string;
+        }
+
+        leaf checksum {
+            description
+              "SHA1 checksum of the image file";
+            type string;
+        }
+
+        leaf dhcp_enable {
+            type boolean;
+        }
+
+        leaf dhcp_range {
+            type string;
+        }
+
+        leaf-list dns {
+            type string;
+        }
+    }
+    grouping connection_point_descriptor {
+        leaf name {
+            type string;
+        }
+
+        leaf id {
+            type string;
+        }
+
+        leaf cp_type {
+            type cp_kind;
+        }
+
+        leaf port_security_enabled {
+            type boolean;
+        }
+
+        leaf require_floating_ip {
+            type boolean;
+        }
+
+        leaf atomic_entity_cp_ref {
+            type string;
+        }
+    }
+
+    grouping virtual_link_descriptor {
+        leaf id {
+            type string;
+        }
+
+        leaf name {
+            type string;
+        }
+
+        leaf is_mgmt {
+            type boolean;
+        }
+
+        leaf short_name {
+            type string;
+        }
+
+        leaf description {
+            type string;
+        }
+
+        leaf vl_type {
+            type vl_kind;
+        }
+
+        leaf root_bandwidth {
+            type int64;
+        }
+
+        leaf leaf_bandwidth {
+            type int64;
+        }
+
+        leaf-list cps {
+            type string;
+        }
+
+        container ip_configuration {
+            uses address_information;
+        }
+    }
+
+    grouping descriptor {
+        leaf uuid {
+            type string;
+        }
+
+        leaf id {
+            type string;
+        }
+
+        leaf description {
+            type string;
+        }
+
+        leaf version {
+            type string;
+        }
+
+        leaf-list atomic_entities {
+            type string;
+        }
+
+        list virtual_links {
+            key "id";
+            uses virtual_link_descriptor;
+        }
+
+        list connection_points {
+            key "id";
+            uses connection_point_descriptor;
+        }
+    }
+
+    container entity_descriptor {
+        uses descriptor;
+    }
+}

--- a/src/im/python/yang/fos/user_entity.yang
+++ b/src/im/python/yang/fos/user_entity.yang
@@ -55,6 +55,23 @@ module user_entity {
         }
     }
 
+    grouping cp_ref {
+        leaf component_id_ref {
+            type string;
+        }
+
+        leaf component_index_ref {
+            type int64;
+        }
+
+        leaf cp_id {
+            type string;
+        }
+
+        leaf has_floating_ip {
+            type boolean;
+        }
+    }
     grouping virtual_link_descriptor {
         leaf id {
             type string;
@@ -88,12 +105,23 @@ module user_entity {
             type int64;
         }
 
-        leaf-list cps {
-            type string;
+        list cps {
+            key "component_index_ref";
+            uses cp_ref;
         }
 
         container ip_configuration {
             uses address_information;
+        }
+    }
+
+    grouping contituent_atomic_entity {
+        leaf id {
+            type string;
+        }
+
+        leaf index {
+            type int64;
         }
     }
 
@@ -118,8 +146,9 @@ module user_entity {
             type string;
         }
 
-        leaf-list atomic_entities {
-            type string;
+        list atomic_entities {
+            key "index";
+            uses contituent_atomic_entity;
         }
 
         list virtual_links {

--- a/src/im/python/yang/fos/user_entity.yang
+++ b/src/im/python/yang/fos/user_entity.yang
@@ -54,31 +54,6 @@ module user_entity {
             type string;
         }
     }
-    grouping connection_point_descriptor {
-        leaf name {
-            type string;
-        }
-
-        leaf id {
-            type string;
-        }
-
-        leaf cp_type {
-            type cp_kind;
-        }
-
-        leaf port_security_enabled {
-            type boolean;
-        }
-
-        leaf require_floating_ip {
-            type boolean;
-        }
-
-        leaf atomic_entity_cp_ref {
-            type string;
-        }
-    }
 
     grouping virtual_link_descriptor {
         leaf id {
@@ -150,11 +125,6 @@ module user_entity {
         list virtual_links {
             key "id";
             uses virtual_link_descriptor;
-        }
-
-        list connection_points {
-            key "id";
-            uses connection_point_descriptor;
         }
     }
 

--- a/src/im/python/yang/fos/user_fdu.yang
+++ b/src/im/python/yang/fos/user_fdu.yang
@@ -325,6 +325,10 @@ module user_fdu {
 
     grouping connection_point {
 
+        leaf uuid {
+            type string;
+        }
+
         leaf name {
             type string;
         }
@@ -345,7 +349,7 @@ module user_fdu {
             type boolean;
         }
 
-        leaf internal_vld_ref {
+        leaf vld_ref {
             description
               "Reference to the VL this CP is connected";
             type string;

--- a/src/utils/ocaml/cli/fos-cli-ng.opam
+++ b/src/utils/ocaml/cli/fos-cli-ng.opam
@@ -28,6 +28,9 @@ depends: [
   "lwt"
   "lwt_ppx"
   "fos-core"
+  "fos-fim-api"
+  "fos-faem-api"
+  "fos-feo-api"
 ]
 
 

--- a/src/utils/ocaml/cli/fos-cli-ng/cli_helper.ml
+++ b/src/utils/ocaml/cli/fos-cli-ng/cli_helper.ml
@@ -10,12 +10,12 @@
  * Contributors: 1
  *   Gabriele Baldoni (gabriele (dot) baldoni (at) adlinktech (dot) com ) - OCaml implementation
  *********************************************************************************)
-
-open Fos_core
-open Fos_im
 open Lwt.Infix
+open Fos_im
+open Fos_core
 open Fos_fim_api
 open Fos_faem_api
+open Fos_feo_api
 
 
 let yaksserver = Apero.Option.get @@ Apero_net.Locator.of_string @@ Apero.Option.get_or_default (Sys.getenv_opt "FOS_YAKS_ENDPOINT") "tcp/127.0.0.1:7887"
@@ -24,6 +24,7 @@ let ytenant = Apero.Option.get_or_default (Sys.getenv_opt "FOS_TENANT_ID") "0"
 
 let yapi u = FIMAPI.connect ~locator:yaksserver ~sysid:ysystem ~tenantid:ytenant u
 let faemapy u = FAEMAPI.connect ~locator:yaksserver ~sysid:ysystem ~tenantid:ytenant u
+let feoapi u = FEOAPI.connect ~locator:yaksserver ~sysid:ysystem ~tenantid:ytenant u
 
 
 let check_descriptor descriptor parser =

--- a/src/utils/ocaml/cli/fos-cli-ng/cli_printing.ml
+++ b/src/utils/ocaml/cli/fos-cli-ng/cli_printing.ml
@@ -121,7 +121,6 @@ let print_fdu_instances ilist  =
     ) ilist
 
 
-
 let print_entities elist =
   let%lwt _ = Lwt_io.printf "+-------------------------------------------------------+\n" in
   Lwt_list.iter_p (

--- a/src/utils/ocaml/cli/fos-cli-ng/dune
+++ b/src/utils/ocaml/cli/fos-cli-ng/dune
@@ -2,6 +2,6 @@
  (name fos_cli_ng)
  (public_name fos)
  (package fos-cli-ng)
- (libraries lwt apero-core lwt.unix str cmdliner uuidm yojson fos-core fos-fim-api fos-faem-api)
+ (libraries lwt apero-core lwt.unix str cmdliner uuidm yojson fos-core fos-fim-api fos-faem-api fos-feo-api)
  (preprocess (pps lwt_ppx ppx_cstruct ))
  )


### PR DESCRIPTION
Implementation of infomation model, types, parsers and APIs for Entity support, this will solve #82

- [x] ATD Types
- [x] OCaml Parsers
- [x] OCaml YAKS Connector functions
- [x] Onboard of Entity in the catalog
- [x] Instantiation/Termination of Entity instance
- [x] Entity APIs OCaml
- [x] YANG Types for Python
- [x] Python Parsers
- [x] Python YAKS Connector functions
- [x] Entity APIs Python
- [x] Entity Managment from CLI
- [x] Verify that there are no regressions and that code works before merging
- [x] Solve #142 
   - [x] Update IM with unified CP descriptors and records between FDU, Atomic Entity and Entity
   - [x] Add function to FIMAPI.Network (VL) for creating a network in a Node
   - [x] Add function to FIMAPI.Network for creating a CP in a Node
   - [x] Add a function to FIMAPI.Network for connect a CP to a Network (VL)
   - [x] Add a function to FIMAPI.FDU for connect a interface to a CP
   - [x] Verify fix

This PR will keep track of the status
  